### PR TITLE
Multiple minor bug fixes

### DIFF
--- a/adventquest_advancements/data/att2/advancements/books/root.json
+++ b/adventquest_advancements/data/att2/advancements/books/root.json
@@ -4,7 +4,7 @@
         "icon": {
             "item": "minecraft:written_book"
         },
-        "title": {"translate":"A Beautiful Life Begins with Reading"},
+        "title": {"translate":"A Beautiful Life Begins by Reading"},
         "description": {"translate":"Young people must read more books"},
         "background": "minecraft:textures/map/map_background.png",
         "show_toast": true,
@@ -17,7 +17,7 @@
                 "items": [
                     {
                         "item":["minecraft:written_book"],
-                        "nbt": "{display:{\"Lore\":[\"{\\\"text\\\":\\\"§7感受你的内在...\\\"}\"]}}"      
+                        "nbt": "{display:{\"Lore\":[\"{\\\"text\\\":\\\"§7感受你的内在...\\\"}\"]}}"
                     }
                 ]
             }
@@ -28,7 +28,7 @@
                 "items": [
                     {
                         "item":["minecraft:written_book"],
-                        "nbt": "{display:{\"Lore\":[\"{\\\"text\\\":\\\"§7Ressentez ce que vous êtes...\\\"}\"]}}"      
+                        "nbt": "{display:{\"Lore\":[\"{\\\"text\\\":\\\"§7Ressentez ce que vous êtes...\\\"}\"]}}"
                     }
                 ]
             }
@@ -39,7 +39,7 @@
                 "items": [
                     {
                         "item":["minecraft:written_book"],
-                        "nbt": "{display:{\"Lore\":[\"{\\\"text\\\":\\\"§7Feel what you are...\\\"}\"]}}"      
+                        "nbt": "{display:{\"Lore\":[\"{\\\"text\\\":\\\"§7Feel what you are...\\\"}\"]}}"
                     }
                 ]
             }
@@ -53,6 +53,3 @@
         ]
     ]
 }
-
-
-

--- a/adventquest_advancements/data/att2/advancements/collection/armor_leather/boots_5.json
+++ b/adventquest_advancements/data/att2/advancements/collection/armor_leather/boots_5.json
@@ -4,7 +4,7 @@
             "item": "minecraft:leather_boots"
         },
         "title": {"translate":"Chaussures délabrées"},
-        "description": {"translate":"Slightly increase your	Dahäl regeneration."},
+        "description": {"translate":"Slightly increase your Dahäl regeneration."},
         "show_toast": false,
         "announce_to_chat": true
     },

--- a/adventquest_advancements/data/att2/advancements/collection/armor_leather/chestplate_3.json
+++ b/adventquest_advancements/data/att2/advancements/collection/armor_leather/chestplate_3.json
@@ -4,7 +4,7 @@
             "item": "minecraft:leather_chestplate"
         },
         "title": {"translate":"Tunique délabrée"},
-        "description": {"translate":"Slightly increase your	Dahäl regeneration."},
+        "description": {"translate":"Slightly increase your Dahäl regeneration."},
         "show_toast": false,
         "announce_to_chat": true
     },

--- a/adventquest_advancements/data/att2/advancements/collection/armor_leather/helmet_2.json
+++ b/adventquest_advancements/data/att2/advancements/collection/armor_leather/helmet_2.json
@@ -4,7 +4,7 @@
             "item": "minecraft:leather_helmet"
         },
         "title": {"translate":"Capuche délabrée"},
-        "description": {"translate":"Slightly increase your	Dahäl regeneration."},
+        "description": {"translate":"Slightly increase your Dahäl regeneration."},
         "show_toast": false,
         "announce_to_chat": true
     },

--- a/adventquest_advancements/data/att2/advancements/collection/armor_leather/leggings_4.json
+++ b/adventquest_advancements/data/att2/advancements/collection/armor_leather/leggings_4.json
@@ -4,7 +4,7 @@
             "item": "minecraft:leather_leggings"
         },
         "title": {"translate":"Braies délabrées"},
-        "description": {"translate":"Slightly increase your	Dahäl regeneration."},
+        "description": {"translate":"Slightly increase your Dahäl regeneration."},
         "show_toast": false,
         "announce_to_chat": true
     },

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/detection/telluron_meleim.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/detection/telluron_meleim.mcfunction
@@ -140,12 +140,6 @@ execute positioned -3744 88 -5828 if data block ~ ~ ~ {LootTable:"att2:chest/reg
 execute positioned -3745 74 -5855 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t2"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
 execute positioned -3745 74 -5846 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t1"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
 execute positioned -3794 96 -5899 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t10"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
-execute positioned -3729 73 -5813 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t4"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
-execute positioned -3729 73 -5814 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t4"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
-execute positioned -3732 76 -5809 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t1"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
-execute positioned -3732 76 -5811 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t1"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
-execute positioned -3732 76 -5816 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t1"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
-execute positioned -3732 76 -5818 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t1"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
 execute positioned -3802 90 -5907 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t4"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
 execute positioned -3748 73 -5799 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t4"} run function att2:gameplay/dahal/action/spell34/create_chest_marker
 execute positioned -3747 74 -5796 if data block ~ ~ ~ {LootTable:"att2:chest/reg1/c2t2"} run function att2:gameplay/dahal/action/spell34/create_chest_marker

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/detection/telluron_silberland.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/detection/telluron_silberland.mcfunction
@@ -256,8 +256,6 @@ execute unless score Schestrown SYMBOL matches 44.. positioned -4414 77 -5061 if
 execute unless score Schestrown SYMBOL matches 44.. positioned -4427 74 -5062 if block ~ ~ ~ minecraft:light run function att2:gameplay/dahal/action/spell34/create_symbol_marker
 execute unless score Schestrown SYMBOL matches 44.. positioned -4328 68 -5054 if block ~ ~ ~ minecraft:light run function att2:gameplay/dahal/action/spell34/create_symbol_marker
 
-execute unless score Worlest_mine SYMBOL matches 14.. positioned -4625 73 -5091 if block ~ ~ ~ minecraft:light run function att2:gameplay/dahal/action/spell34/create_symbol_marker
-
 execute unless score Secret_dungeon SYMBOL matches 34.. positioned -4375 64 -6223 if block ~ ~ ~ minecraft:light run function att2:gameplay/dahal/action/spell34/create_symbol_marker
 execute unless score Secret_dungeon SYMBOL matches 34.. positioned -4321 52 -6192 if block ~ ~ ~ minecraft:light run function att2:gameplay/dahal/action/spell34/create_symbol_marker
 execute unless score Secret_dungeon SYMBOL matches 34.. positioned -4386 63 -6225 if block ~ ~ ~ minecraft:light run function att2:gameplay/dahal/action/spell34/create_symbol_marker

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl1.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl1.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl10.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl10.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl2.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl2.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl3.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl3.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl4.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl4.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl5.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl5.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl6.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl6.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl7.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl7.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl8.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl8.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl9.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dahal/action/spell34/lvl9.mcfunction
@@ -7,16 +7,16 @@ scoreboard players set @s LIMIT34 0
 
 execute as @s[scores={DIMENSION=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_past
 execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron
-execute as @s[scores={DIMENSION=1,AREA=0}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
-execute as @s[scores={DIMENSION=1,AREA=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
-execute as @s[scores={DIMENSION=1,AREA=2}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
-execute as @s[scores={DIMENSION=1,AREA=3}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
-execute as @s[scores={DIMENSION=1,AREA=4}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
-execute as @s[scores={DIMENSION=1,AREA=5}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
-execute as @s[scores={DIMENSION=1,AREA=6}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
-execute as @s[scores={DIMENSION=1,AREA=7}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
-execute as @s[scores={DIMENSION=1,AREA=8}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
-execute as @s[scores={DIMENSION=1,AREA=10}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_ryliath
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_worlest
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_silberland
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_owsastr
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_meleim
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_asunark
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_eolorion
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_nojelanth
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_earndhel
+execute as @s[scores={DIMENSION=1}] run function att2:gameplay/dahal/action/spell34/detection/telluron_desert
 execute as @s[scores={DIMENSION=4..5}] run function att2:gameplay/dahal/action/spell34/detection/ouranos
 execute as @s[scores={DIMENSION=6}] run function att2:gameplay/dahal/action/spell34/detection/angband
 execute as @s[scores={DIMENSION=7}] run function att2:gameplay/dahal/action/spell34/detection/billgart

--- a/adventquest_functions/data/att2/functions/gameplay/misc/chesteffect/go.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/misc/chesteffect/go.mcfunction
@@ -1023,25 +1023,6 @@ execute in minecraft:overworld if data block -3745 74 -5846 {LootTable:"att2:che
 execute in minecraft:overworld if data block -3794 96 -5899 {LootTable:"att2:chest/reg1/c2t10"} positioned -3794 96 -5899 run particle minecraft:dust 0.75 0.25 0.0 0.25 ~ ~0.5 ~ 0.3 0.3 0.3 0 10 normal
 
 
-execute in minecraft:overworld if data block -3729 73 -5813 {LootTable:"att2:chest/reg1/c2t4"} positioned -3729 73 -5813 run particle minecraft:dust 0.25 0.5 0.5 0.25 ~ ~0.5 ~ 0.3 0.3 0.3 0 10 normal
-execute in minecraft:overworld if data block -3729 73 -5814 {LootTable:"att2:chest/reg1/c2t4"} positioned -3729 73 -5814 run particle minecraft:dust 0.25 0.5 0.5 0.25 ~ ~0.5 ~ 0.3 0.3 0.3 0 10 normal
-
-
-
-
-
-
-
-
-
-
-
-
-execute in minecraft:overworld if data block -3732 76 -5809 {LootTable:"att2:chest/reg1/c2t1"} positioned -3732 76 -5809 run particle minecraft:dust 0.5 0.5 0.5 0.25 ~ ~0.5 ~ 0.3 0.3 0.3 0 10 normal
-execute in minecraft:overworld if data block -3732 76 -5811 {LootTable:"att2:chest/reg1/c2t1"} positioned -3732 76 -5811 run particle minecraft:dust 0.5 0.5 0.5 0.25 ~ ~0.5 ~ 0.3 0.3 0.3 0 10 normal
-execute in minecraft:overworld if data block -3732 76 -5816 {LootTable:"att2:chest/reg1/c2t1"} positioned -3732 76 -5816 run particle minecraft:dust 0.5 0.5 0.5 0.25 ~ ~0.5 ~ 0.3 0.3 0.3 0 10 normal
-execute in minecraft:overworld if data block -3732 76 -5818 {LootTable:"att2:chest/reg1/c2t1"} positioned -3732 76 -5818 run particle minecraft:dust 0.5 0.5 0.5 0.25 ~ ~0.5 ~ 0.3 0.3 0.3 0 10 normal
-
 
 execute in minecraft:overworld if data block -3802 90 -5907 {LootTable:"att2:chest/reg1/c2t4"} positioned -3802 90 -5907 run particle minecraft:dust 0.25 0.5 0.5 0.25 ~ ~0.5 ~ 0.3 0.3 0.3 0 10 normal
 execute in minecraft:overworld if data block -3748 73 -5799 {LootTable:"att2:chest/reg1/c2t4"} positioned -3748 73 -5799 run particle minecraft:dust 0.25 0.5 0.5 0.25 ~ ~0.5 ~ 0.3 0.3 0.3 0 10 normal

--- a/adventquest_functions/data/att2/functions/gameplay/shop/slot_management/showcase/armor_wulk.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/shop/slot_management/showcase/armor_wulk.mcfunction
@@ -80,10 +80,10 @@ execute if score @s SHOP_OP1 matches 966..967 at @e[name="WULK"] as @a[distance=
 execute if score @s SHOP_OP1 matches 968..969 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/leather_chestplate_49
 execute if score @s SHOP_OP1 matches 970..971 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/leather_leggings_50
 execute if score @s SHOP_OP1 matches 972..973 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/leather_boots_51
-execute if score @s SHOP_OP1 matches 974..975 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/leather_helmet_64
-execute if score @s SHOP_OP1 matches 976..977 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/leather_chestplate_65
-execute if score @s SHOP_OP1 matches 978..979 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/leather_leggings_66
-execute if score @s SHOP_OP1 matches 980..981 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/leather_boots_67
+execute if score @s SHOP_OP1 matches 974..975 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi_set/leather_helmet_64
+execute if score @s SHOP_OP1 matches 976..977 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi_set/leather_chestplate_65
+execute if score @s SHOP_OP1 matches 978..979 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi_set/leather_leggings_66
+execute if score @s SHOP_OP1 matches 980..981 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi_set/leather_boots_67
 execute if score @s SHOP_OP1 matches 982..983 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/chainmail_helmet_90
 execute if score @s SHOP_OP1 matches 984..985 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/chainmail_helmet_91
 execute if score @s SHOP_OP1 matches 986..987 at @e[name="WULK"] as @a[distance=..7] run function att2:dialogs/gameplay/shop/showcase/armor/epi/chainmail_chestplate_92

--- a/adventquest_loot_tables/data/att2/loot_tables/chest/reg2/c10t4.json
+++ b/adventquest_loot_tables/data/att2/loot_tables/chest/reg2/c10t4.json
@@ -1674,7 +1674,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{EquipmentType:\"potion\",Rarity:\"epi\",Effect:\"\",display:{Name:\"\\\"§5Gaz nauséabond\\\"\",\"Lore\":[\"{\\\"text\\\":\\\"§7Crée un nuage troub,e écœurant\\\"}\",\"{\\\"text\\\":\\\"§7et causant ainsi des nausées.\\\"}\",\"{\\\"text\\\":\\\"§7Creates a sickening cloud causing nausea.\\\"}\"]},CustomPotionColor:1920810,custom_potion_effects:[{id:wither,amplifier:6,duration:500,show_particles:0b},{id:blindness,amplifier:0,duration:500,show_particles:0b},{id:instant_damage,amplifier:6,duration:0,show_particles:0b}]}"
+                            "tag": "{EquipmentType:\"potion\",Rarity:\"epi\",Effect:\"\",display:{Name:\"\\\"§5Gaz nauséabond\\\"\",\"Lore\":[\"{\\\"text\\\":\\\"§7Crée un nuage trouble écœurant\\\"}\",\"{\\\"text\\\":\\\"§7et causant ainsi des nausées.\\\"}\",\"{\\\"text\\\":\\\"§7Creates a sickening cloud causing nausea.\\\"}\"]},CustomPotionColor:1920810,custom_potion_effects:[{id:wither,amplifier:6,duration:500,show_particles:0b},{id:blindness,amplifier:0,duration:500,show_particles:0b},{id:instant_damage,amplifier:6,duration:0,show_particles:0b}]}"
                         }
                     ]
                 },


### PR DESCRIPTION
#16
#15
- Removed the area restriction for secret seeker spell, removing it doesn't lag much and it was causing annoying issues.
- Fixed wulk epic set showcase.
- Fixed broken symbol in délabrée leather set advancements.
- Removed chest markers from unreachable méleïm chests.
- Minor spelling fix and shortened slightly the books root adv.
- Removed duplicate marker entry.