### PR TITLE
Achievement branch fix and nofight dialog loop or player cant leave and  GPS location fix

### DIFF
--- a/adventquest_advancements/data/att2/advancements/collection/armor_iron/all.json
+++ b/adventquest_advancements/data/att2/advancements/collection/armor_iron/all.json
@@ -7,7 +7,7 @@
         "description": {"translate":"Find all Traditional armor"},
         "frame": "challenge"
     },
-    "parent": "att2:collection/armor_diamond",
+    "parent": "att2:collection/armor_iron",
     "rewards": {
         "function": "att2:advancement/exploit_25",
         "experience": 10000

--- a/adventquest_functions/data/att2/functions/cinematic/act_4/gem_of_time/give_gem.mcfunction
+++ b/adventquest_functions/data/att2/functions/cinematic/act_4/gem_of_time/give_gem.mcfunction
@@ -3,6 +3,6 @@
 #True for the player Inventory and give the gem 				#
 #################################################################
 
-function att2:cinematic/act_2/gem_of_time/effect
+function att2:cinematic/act_4/gem_of_time/effect
 function att2:items/quest/gem_of_time
 execute as @e[type=minecraft:armor_stand,distance=..7,nbt={HandItems:[{id:"minecraft:clay_ball",Count:1b}]}] at @s run kill @s

--- a/adventquest_functions/data/att2/functions/dialogs/mainquest/act_4/pnj_ouran/dialog_18.mcfunction
+++ b/adventquest_functions/data/att2/functions/dialogs/mainquest/act_4/pnj_ouran/dialog_18.mcfunction
@@ -12,6 +12,8 @@ advancement grant @a only att2:adventure/ouran_nofight
 scoreboard players set Real0 TIMER 1501
 scoreboard players set ouran_PNJ DIALOG -2
 scoreboard players set Ouran OURANOS -2
+## stop ouran_2_go
+setblock 7887 103 6771 minecraft:air
 
 
 #FRENCH LANGUAGE

--- a/adventquest_functions/data/att2/functions/gameplay/quest/mainquest/step117_119.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/quest/mainquest/step117_119.mcfunction
@@ -5,6 +5,6 @@
 
 scoreboard players set Objective GPS_DIM 1
 function att2:dialogs/mainquest/assistance/step117_119
-execute in minecraft:overworld positioned -5034 78 -5036 run function att2:gameplay/gps/summon_arrow
-execute in minecraft:overworld as @e[tag=newGPS] at @s anchored feet facing -5034 78 -5036 run function att2:gameplay/gps/tp_arrow
+execute in minecraft:overworld positioned -5026 77 -5037 run function att2:gameplay/gps/summon_arrow
+execute in minecraft:overworld as @e[tag=newGPS] at @s anchored feet facing -5026 77 -5037 run function att2:gameplay/gps/tp_arrow
 execute in minecraft:overworld positioned -5611 159 -6531 run function att2:gameplay/quest/mainquest/show_secondary_objective

--- a/adventquest_functions/data/att2/functions/gameplay/quest/mainquest/step172_179.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/quest/mainquest/step172_179.mcfunction
@@ -5,5 +5,5 @@
 
 scoreboard players set Objective GPS_DIM 1
 function att2:dialogs/mainquest/assistance/step172_179
-execute in minecraft:overworld positioned -5034 78 -5036 run function att2:gameplay/gps/summon_arrow
-execute in minecraft:overworld as @e[tag=newGPS] at @s anchored feet facing -5034 78 -5036 run function att2:gameplay/gps/tp_arrow
+execute in minecraft:overworld positioned -5029 77 -5037 run function att2:gameplay/gps/summon_arrow
+execute in minecraft:overworld as @e[tag=newGPS] at @s anchored feet facing -5029 77 -5037 run function att2:gameplay/gps/tp_arrow

--- a/adventquest_functions/data/att2/functions/gameplay/quest/mainquest/step218.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/quest/mainquest/step218.mcfunction
@@ -5,5 +5,5 @@
 
 scoreboard players set Objective GPS_DIM 1
 function att2:dialogs/mainquest/assistance/step218
-execute in minecraft:overworld positioned -5034 78 -5036 run function att2:gameplay/gps/summon_arrow
-execute in minecraft:overworld as @e[tag=newGPS] at @s anchored feet facing -5034 78 -5036 run function att2:gameplay/gps/tp_arrow
+execute in minecraft:overworld positioned -5031 77 -5037 run function att2:gameplay/gps/summon_arrow
+execute in minecraft:overworld as @e[tag=newGPS] at @s anchored feet facing -5031 77 -5037 run function att2:gameplay/gps/tp_arrow

--- a/adventquest_functions/data/att2/functions/gameplay/quest/mainquest/step280_281.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/quest/mainquest/step280_281.mcfunction
@@ -5,5 +5,5 @@
 
 scoreboard players set Objective GPS_DIM 1
 function att2:dialogs/mainquest/assistance/step280_281
-execute in minecraft:overworld positioned -5034 78 -5036 run function att2:gameplay/gps/summon_arrow
-execute in minecraft:overworld as @e[tag=newGPS] at @s anchored feet facing -5034 78 -5036 run function att2:gameplay/gps/tp_arrow
+execute in minecraft:overworld positioned -5034 77 -5037 run function att2:gameplay/gps/summon_arrow
+execute in minecraft:overworld as @e[tag=newGPS] at @s anchored feet facing -5034 77 -5037 run function att2:gameplay/gps/tp_arrow


### PR DESCRIPTION
The GPS guidance for some gems does not correspond to the appropriate gem slots.

When the player selects "nofight" and obtains the time gem, a red stone block is placed in the spawn area after detecting the time gem in the player's inventory. Then, the ouran_3_go process begins. However, at this time, ouran_2_go is still running and executing the count from 1502 to 1900. The concurrent operation of these two goroutines causes conflicts, preventing the player from teleporting properly and triggering an endless loop of dialogues.

SO When "nofight" is selected, add an instruction to clear the red stone block of ouran_2_go, and ouran_3_go will operate normally.