### PR TITLE
Fixed the bug of riding through portals + accidental death of stock +guardian kill detection

### DIFF
--- a/adventquest_advancements/data/att2_test/advancements/test_mobskilled/guardian.json
+++ b/adventquest_advancements/data/att2_test/advancements/test_mobskilled/guardian.json
@@ -4,20 +4,20 @@
             "item": "minecraft:target"
         },
         "title": {"translate":"test"},
-        "description": {"translate":"magma_cube"},
+        "description": {"translate":"guardian"},
         "hidden": true,
         "show_toast": false,
         "announce_to_chat": false
     },
     "rewards": {
-        "function": "att2:advancement/test_all/mobskilled/magma_cube"
+        "function": "att2:advancement/test_all/mobskilled/guardian"
     },
     "criteria": {
-        "minecraft:magma_cube": {
+        "minecraft:guardian": {
           "trigger": "minecraft:player_killed_entity",
           "conditions": {
             "entity": {
-              "type": "minecraft:magma_cube"
+              "type": "minecraft:guardian"
             }
           }
         }

--- a/adventquest_functions/data/att2/functions/gameplay/boss/angband/flamme_noire/start_dying.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/boss/angband/flamme_noire/start_dying.mcfunction
@@ -8,4 +8,4 @@ scoreboard players set FlammeNoire ANGOR -2
 scoreboard players set FlammeNoire ANGOR_BOSS 210
 execute as @a run bossbar set minecraft:flamme_noire visible false
 execute as @a run bossbar remove minecraft:flamme_noire
-execute in minecraft:the_nether run kill @e[type=!minecraft:player,type=!minecraft:item,x=3545,y=74,z=4887,dx=-77,dy=-44,dz=43]
+execute in minecraft:the_nether run kill @e[type=!minecraft:player,tag=!spell20_chest,type=!minecraft:item,x=3545,y=74,z=4887,dx=-77,dy=-44,dz=43]

--- a/adventquest_functions/data/att2/functions/gameplay/dimension/portals/telluron_angband.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dimension/portals/telluron_angband.mcfunction
@@ -4,14 +4,14 @@
 #################################################################
 
 # In transition from Tellurön
-execute in minecraft:overworld as @e[x=30009,y=80,z=29936,dx=5,dy=-3,dz=0,tag=!spell20_chest,tag=!Spell_Pet] run tp @s -3336.0 127 4935 -180 ~
+execute in minecraft:overworld as @a[x=30009,y=80,z=29936,dx=5,dy=-3,dz=0] run tp @s -3336.0 127 4935 -180 ~
 # Out transition to Angband
-execute in minecraft:overworld as @e[x=-3335,y=127,z=4902,dx=-3,dy=2,dz=0,tag=!spell20_chest,tag=!Spell_Pet] in minecraft:the_nether run function att2:gameplay/dimension/portals/tp_to_angband
+execute in minecraft:overworld as @a[x=-3335,y=127,z=4902,dx=-3,dy=2,dz=0] in minecraft:the_nether run function att2:gameplay/dimension/portals/tp_to_angband
 
 # In transition from Angband
-execute in minecraft:the_nether as @e[x=3750,y=86,z=3749,dx=-1,dy=1,dz=0,tag=!spell20_chest,tag=!Spell_Pet] in minecraft:overworld run tp @s -3336.0 127 4903 0 ~
+execute in minecraft:the_nether as @a[x=3750,y=86,z=3749,dx=-1,dy=1,dz=0] in minecraft:overworld run tp @s -3336.0 127 4903 0 ~
 # Out transition to Tellurön
-execute in minecraft:overworld as @e[x=-3334,y=126,z=4936,dx=-5,dy=2,dz=0,tag=!spell20_chest,tag=!Spell_Pet] run tp @s 30012.0 77 29937 0 ~
+execute in minecraft:overworld as @a[x=-3334,y=126,z=4936,dx=-5,dy=2,dz=0] run tp @s 30012.0 77 29937 0 ~
 
 # Particle for Tellurön's portal, inner side
 execute in minecraft:overworld run particle minecraft:bubble_pop -3336.0 129 4901 1 1 0 0.1 20 normal

--- a/adventquest_functions/data/att2/functions/gameplay/dimension/portals/telluron_billgart.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dimension/portals/telluron_billgart.mcfunction
@@ -4,14 +4,14 @@
 #################################################################
 
 # In transition from Tellurön
-execute in minecraft:overworld as @e[x=-5071,y=148,z=-4878,dx=0,dy=5,dz=-4,tag=!spell20_chest,tag=!Spell_Pet] run tp @s -3176.0 126 4935 -180 ~
+execute in minecraft:overworld as @a[x=-5071,y=148,z=-4878,dx=0,dy=5,dz=-4] run tp @s -3176.0 126 4935 -180 ~
 # Out transition to Billgart
-execute in minecraft:overworld as @e[x=-3179,y=126,z=4902,dx=5,dy=5,dz=0,tag=!spell20_chest,tag=!Spell_Pet] in minecraft:the_end run function att2:gameplay/dimension/portals/tp_to_billgart
+execute in minecraft:overworld as @a[x=-3179,y=126,z=4902,dx=5,dy=5,dz=0] in minecraft:the_end run function att2:gameplay/dimension/portals/tp_to_billgart
 
 # In transition from Billgart
-execute in minecraft:the_end as @e[x=-641,y=94,z=-605,dx=0,dy=5,dz=-5,tag=!spell20_chest,tag=!Spell_Pet] in minecraft:overworld run tp @s -3176.0 127 4903 0 ~
+execute in minecraft:the_end as @a[x=-641,y=94,z=-605,dx=0,dy=5,dz=-5] in minecraft:overworld run tp @s -3176.0 127 4903 0 ~
 # Out transition to Tellurön
-execute in minecraft:overworld as @e[x=-3174,y=126,z=4937,dx=-4,dy=4,dz=0,tag=!spell20_chest,tag=!Spell_Pet] run tp @s -5069 149 -4880 -90 ~
+execute in minecraft:overworld as @a[x=-3174,y=126,z=4937,dx=-4,dy=4,dz=0] run tp @s -5069 149 -4880 -90 ~
 
 # Particle for Tellurön's portal, inner side
 execute in minecraft:overworld run particle minecraft:bubble_pop -3176.0 129 4902.5 1.2 1.2 0.05 0.1 25 normal

--- a/adventquest_functions/data/att2/functions/gameplay/dimension/portals/telluron_ouranos.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/dimension/portals/telluron_ouranos.mcfunction
@@ -4,14 +4,14 @@
 #################################################################
 
 # In transition from Tellurön
-execute as @e[x=-5011,y=140,z=-4890,dx=0,dy=18,dz=20,tag=!spell20_chest,tag=!Spell_Pet] run tp @s -3017 126 4935 -180 ~
+execute as @a[x=-5011,y=140,z=-4890,dx=0,dy=18,dz=20] run tp @s -3017 126 4935 -180 ~
 # Out transition to Ouranos
-execute as @e[x=-3019,y=126,z=4902,dx=5,dy=5,dz=0,tag=!spell20_chest,tag=!Spell_Pet] run function att2:gameplay/dimension/portals/tp_to_ouranos
+execute as @a[x=-3019,y=126,z=4902,dx=5,dy=5,dz=0] run function att2:gameplay/dimension/portals/tp_to_ouranos
 
 # In transition from Ouranos
-execute as @e[x=6998,y=77,z=6998,dx=0,dy=4,dz=4,tag=!spell20_chest,tag=!Spell_Pet] run tp @s -3017 127 4903 0 ~
+execute as @a[x=6998,y=77,z=6998,dx=0,dy=4,dz=4] run tp @s -3017 127 4903 0 ~
 # Out transition to Tellurön
-execute as @e[x=-3014,y=126,z=4937,dx=-4,dy=4,dz=0,tag=!spell20_chest,tag=!Spell_Pet] run tp @s -5013 149 -4880 90 ~
+execute as @a[x=-3014,y=126,z=4937,dx=-4,dy=4,dz=0] run tp @s -5013 149 -4880 90 ~
 
 # Particle for Tellurön's portal, inner side
 particle minecraft:bubble_pop -3016.0 128 4902.5 4 4 0.05 0.1 100 normal

--- a/adventquest_functions/data/att2/functions/gameplay/shop/indication/blacksmith.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/shop/indication/blacksmith.mcfunction
@@ -6,7 +6,7 @@
 #Ryliath
 execute in minecraft:overworld positioned -5064 103 -4961 if entity @s[distance=..150,gamemode=adventure] run function att2:gameplay/shop/indication/blacksmith/ryliath
 #Eolorion
-execute in minecraft:overworld positioned -5274 117 -6237 if entity @s[distance=..150,gamemode=adventure] run function att2:gameplay/shop/indication/blacksmith/eolorion
+execute in minecraft:overworld positioned -5250 101 -6222 if entity @s[distance=..150,gamemode=adventure] run function att2:gameplay/shop/indication/blacksmith/eolorion
 #Kortaek
 execute in minecraft:overworld positioned -5464 52 -4706 if entity @s[distance=..150,gamemode=adventure] run function att2:gameplay/shop/indication/blacksmith/kortaek
 #Zirthion

--- a/adventquest_functions/data/att2/functions/gameplay/shop/indication/blacksmith/eolorion.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/shop/indication/blacksmith/eolorion.mcfunction
@@ -5,5 +5,5 @@
 
 scoreboard players set Objective GPS_DIM 1
 function att2:gameplay/gps/summon_arrow
-execute as @e[tag=newGPS] at @s anchored feet facing -5274 117 -6237 run function att2:gameplay/gps/tp_arrow
+execute as @e[tag=newGPS] at @s anchored feet facing -5250 101 -6222 run function att2:gameplay/gps/tp_arrow
 effect give 00000000-0000-074a-0000-00000000074a minecraft:glowing 15 0 true

--- a/adventquest_functions/data/att2/functions/gameplay/shop/indication/runemaster.mcfunction
+++ b/adventquest_functions/data/att2/functions/gameplay/shop/indication/runemaster.mcfunction
@@ -4,4 +4,4 @@
 #####################################################################
 
 #Ryliath
-execute in minecraft:overworld positioned -5071 91 -5019 if entity @s[distance=..150,gamemode=adventure] run function att2:gameplay/shop/indication/runemaster/ryliath
+execute in minecraft:overworld positioned -5029 91 -4964 if entity @s[distance=..150,gamemode=adventure] run function att2:gameplay/shop/indication/runemaster/ryliath


### PR DESCRIPTION

There is an issue with the dimensional teleportation detection range. If a player rides a horse into a portal, due to the large collision volume of the horse, the position detection will loop and continuously teleport the horse, trapping the player on the horse and preventing movement. Other entities, such as pets or others, might also encounter this problem.

So replacing @e with @a should have no impact.