### PR TITLE
fix typo mainquest act1

### DIFF
--- a/adventquest_functions/data/att2/functions/dialogs/mainquest/act_1/ch0_serile_16.mcfunction
+++ b/adventquest_functions/data/att2/functions/dialogs/mainquest/act_1/ch0_serile_16.mcfunction
@@ -13,7 +13,7 @@ tellraw @a[scores={LANGUAGE=0}] {"text":" °-° S : ","color":"gray","extra":[{"
 
 #ENGLISH LANGUAGE
 
-tellraw @a[scores={LANGUAGE=1}] {"text":" °-° S : ","color":"gray","extra":[{"text":"Shit! We're soon gonna be out of time! Get the last gem, fast!!","color":"yellow","italic":true}]}
+tellraw @a[scores={LANGUAGE=1}] {"text":" °-° S : ","color":"gray","extra":[{"text":"Shit! We're soon gonna be out of time! Get the last gem, quick!!","color":"yellow","italic":true}]}
 
 
 #CHINESE LANGUAGE


### PR DESCRIPTION
This is a typo fix for the english since "Quick" is more grammatically correct than "Fast" (and it sounds better)