### PR TITLE
fix enchantments predicate error

### DIFF
--- a/adventquest_function/data/att2/function/gameplay/enchantment/arcanedrive/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enchantment/arcanedrive/go.mcfunction
@@ -6,8 +6,8 @@
 
 execute store result score temp_value_1 CAL run data get entity @s equipment.legs.components."minecraft:enchantments"."att2_enchantment:arcanedrive"
 #get DAR number
-execute if predicate att2_pre:att2_pre:dahal/hold_main run scoreboard players operation temp_value_2 CAL += temp_value_1 CAL
-execute if predicate att2_pre:att2_pre:dahal/hold_off run scoreboard players operation temp_value_2 CAL += temp_value_1 CAL
+execute if predicate att2_pre:dahal/hold_main run scoreboard players operation temp_value_2 CAL += temp_value_1 CAL
+execute if predicate att2_pre:dahal/hold_off run scoreboard players operation temp_value_2 CAL += temp_value_1 CAL
 #ger score
 scoreboard players operation DAR ATTRIBUTE = temp_value_2 CAL
 #return DAR number

--- a/adventquest_function/data/att2/function/gameplay/enchantment/trigger_function/arcanedrive.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enchantment/trigger_function/arcanedrive.mcfunction
@@ -3,4 +3,4 @@
 #cal actually damage >=< theory mini damage                   	#
 #################################################################
 
-execute if predicate att2_pre:enchantment/arcanedrive/legs if predicate att2_pre:enchantment/arcanedrive/dahal_hold run function att2:gameplay/enchantment/arcanedrive/go
+execute if predicate att2_pre:enchantment/arcanedrive/legs if predicate att2_pre:test_hold/dahal_hold run function att2:gameplay/enchantment/arcanedrive/go


### PR DESCRIPTION
I'm not entirely sure - my eternan equipment section isn't throwing any errors. Did you update the adventquest_item_modifier file during your testing?