### PR TITLE
Add monster shield functionality.

### DIFF
--- a/adventquest_function/data/att2/function/gameplay/enemy_health/kill.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enemy_health/kill.mcfunction
@@ -3,6 +3,9 @@
 #detect enemy health reduce                                     #
 #################################################################
 
+
+##add tag
+tag @s add killed
 ##clear enchantments
 data remove entity @s equipment.head.components."minecraft:enchantments"
 ##health 0

--- a/adventquest_function/data/att2/function/gameplay/enemy_health/melee_health_trigger.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enemy_health/melee_health_trigger.mcfunction
@@ -15,6 +15,10 @@ execute store result score #max_health CAL run attribute @s max_health get
 scoreboard players set #reduce_health CAL 1000
 scoreboard players operation #reduce_health CAL -= #health CAL
 #scoreboard players operation #reduce_health CAL < #max_health CAL
+
+##shield effect
+execute if items entity @s weapon.offhand shield run function att2:gameplay/leveling/monster/shield_enemy/block_trigger
+
 ##absorption_health
 execute if score #reduce_health CAL matches 1.. unless score @s ENEMYABHEALTH matches ..0 run function att2:gameplay/enemy_health/absorption_health_trigger
 execute if score #absorption_health CAL matches 1.. run function att2:gameplay/enemy_health/show_absorption_health_reduce/melee
@@ -31,7 +35,7 @@ execute as @s[tag=killed] run return run function att2:gameplay/enemy_health/kil
 execute as @s[type=!bat] at @s run function att2:gameplay/enemy_health/show_health_reduce/melee
 ##update healthbar
 function att2:gameplay/healthbar/detection_enemy
-scoreboard players set #reduce_health CAL 0
+#scoreboard players set #reduce_health CAL 0
 execute if score @s ENEMYHEALTH matches ..0 run tag @s add killed
 execute if score @s ENEMYHEALTH matches ..0 at @s on attacker run damage @n[distance=..0,tag=killed] 7777777777777777 att2_damage:player_attack by @s
 execute if score @s ENEMYHEALTH matches ..0 run return run function att2:gameplay/enemy_health/kill

--- a/adventquest_function/data/att2/function/gameplay/enemy_health/mob_tick.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enemy_health/mob_tick.mcfunction
@@ -10,6 +10,6 @@ function att2:gameplay/misc/wither_damage/damage_cal
 ##test in lava
 function att2:gameplay/enveffect/lava/enemy_damage
 ##angry
-execute if score tic TIMECOUNTER matches 1 as @s[type=#minecraft:angry] unless data entity @s angry_at run data modify entity @s angry_at set from entity @p UUID
+execute if score tic TIMECOUNTER matches 1 as @s[type=#minecraft:angry,team=!ally] unless data entity @s angry_at run data modify entity @s angry_at set from entity @p UUID
 ##test health reduce
 function att2:gameplay/enemy_health/normal_trigger

--- a/adventquest_function/data/att2/function/gameplay/enemy_health/normal_trigger.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enemy_health/normal_trigger.mcfunction
@@ -36,7 +36,6 @@ execute as @s[type=!bat] at @s run function att2:gameplay/enemy_health/show_heal
 ##update healthbar
 function att2:gameplay/healthbar/detection_enemy
 scoreboard players set #reduce_health CAL 0
-execute if score @s ENEMYHEALTH matches ..0 run tag @s add killed
 execute if score @s ENEMYHEALTH matches ..0 run return run function att2:gameplay/enemy_health/kill
 
 ##make health trigger full

--- a/adventquest_function/data/att2/function/gameplay/enemy_health/real_health_trigger.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enemy_health/real_health_trigger.mcfunction
@@ -26,7 +26,6 @@ execute as @s[type=!bat] at @s run function att2:gameplay/enemy_health/show_heal
 ##update healthbar
 function att2:gameplay/healthbar/detection_enemy
 scoreboard players set #reduce_health CAL 0
-execute if score @s ENEMYHEALTH matches ..0 run tag @s add killed
 execute if score @s ENEMYHEALTH matches ..0 run return run function att2:gameplay/enemy_health/kill
 
 ##make health trigger full

--- a/adventquest_function/data/att2/function/gameplay/enemy_health/show_health_reduce/arrow.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enemy_health/show_health_reduce/arrow.mcfunction
@@ -27,3 +27,10 @@ data modify entity @n[distance=..10,type=item,tag=New,tag=HPDISPLAY] Motion set 
 tag @e[distance=..10,type=text_display,tag=New,tag=HPDISPLAY] remove New
 tag @e[distance=..10,type=item,tag=New,tag=HPDISPLAY] remove New
 tag @e[distance=..10,type=armor_stand,tag=New,tag=HPDISPLAY] remove New
+
+##particle
+execute if score #reduce_health CAL matches ..10 run particle minecraft:item{item:"minecraft:arrow"} ~ ~1 ~ 0.5 0.5 0.5 0.1 15 normal
+execute if score #reduce_health CAL matches 11..30 run particle minecraft:item{item:"minecraft:arrow"} ~ ~1 ~ 0.5 0.5 0.5 0.1 25 normal
+execute if score #reduce_health CAL matches 31..50 run particle minecraft:item{item:"minecraft:arrow"} ~ ~1 ~ 0.5 0.5 0.5 0.1 45 normal
+execute if score #reduce_health CAL matches 51..90 run particle minecraft:item{item:"minecraft:arrow"} ~ ~1 ~ 0.5 0.5 0.5 0.1 75 normal
+execute if score #reduce_health CAL matches 91.. run particle minecraft:item{item:"minecraft:arrow"} ~ ~1 ~ 0.5 0.5 0.5 0.1 120 normal

--- a/adventquest_function/data/att2/function/gameplay/enemy_health/show_health_reduce/melee.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enemy_health/show_health_reduce/melee.mcfunction
@@ -27,3 +27,11 @@ data modify entity @n[distance=..10,type=item,tag=New,tag=HPDISPLAY] Motion set 
 tag @e[distance=..10,type=text_display,tag=New,tag=HPDISPLAY] remove New
 tag @e[distance=..10,type=item,tag=New,tag=HPDISPLAY] remove New
 tag @e[distance=..10,type=armor_stand,tag=New,tag=HPDISPLAY] remove New
+
+##particle
+execute if score #reduce_health CAL matches ..10 run particle minecraft:item{item:"minecraft:redstone_block"} ~ ~1 ~ 0.5 0.5 0.5 0.1 5 normal
+execute if score #reduce_health CAL matches 11..30 run particle minecraft:item{item:"minecraft:redstone_block"} ~ ~1 ~ 0.5 0.5 0.5 0.1 10 normal
+execute if score #reduce_health CAL matches 31..50 run particle minecraft:item{item:"minecraft:redstone_block"} ~ ~1 ~ 0.5 0.5 0.5 0.1 30 normal
+execute if score #reduce_health CAL matches 51..90 run particle minecraft:item{item:"minecraft:redstone_block"} ~ ~1 ~ 0.5 0.5 0.5 0.1 60 normal
+execute if score #reduce_health CAL matches 91.. run particle minecraft:item{item:"minecraft:redstone_block"} ~ ~1 ~ 0.5 0.5 0.5 0.1 100 normal
+

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/damage.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/damage.mcfunction
@@ -4,7 +4,7 @@
 #################################################################
 
 ##facing
-rotate @n[distance=..10,type=marker,tag=Temp] facing entity @s eyes
+rotate @n[distance=..10,type=marker,tag=Temp] facing entity @s feet
 ##sync rotation
 data modify entity 00000001-0000-006f-0000-00010000006f Rotation set from entity @n[distance=..10,type=marker,tag=Temp] Rotation
 ##tp

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/damage_detection.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/damage_detection.mcfunction
@@ -27,3 +27,6 @@ execute on passengers if items entity @s container.0 *[custom_data~{Rarity:myt}]
 ##return data
 execute store result entity @s item.components."minecraft:damage" int 1 run scoreboard players get #damage CAL
 execute on passengers store result entity @s item.components."minecraft:damage" int 1 run scoreboard players get #damage CAL
+
+#tellraw @a [{score:{name:"#damage",objective:"CAL"}}]
+#tellraw @a [{score:{name:"#max_damage",objective:"CAL"}}]

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/go.mcfunction
@@ -17,9 +17,12 @@ execute unless score @s AXECOOLDOWN matches 0 run return fail
 
 
 ##revoke test
-advancement revoke @s only att2_test:test_weapon/switch_axe_trigger
+advancement revoke @s only att2_test:test_weapon/switch_axe_trigger	
+scoreboard players set @s AXECOOLDOWN -100
+
+
+##sound tip
+execute unless items entity @s weapon.* #minecraft:axes run return fail
 playsound minecraft:unsheathe1 master @a ~ ~ ~ 1 0.5
 playsound minecraft:item.axe.wax_off master @a ~ ~ ~ 1 1
 playsound minecraft:item.trident.return master @a ~ ~ ~ 1 2
-	
-scoreboard players set @s AXECOOLDOWN -100

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/launch_detection.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/launch_detection.mcfunction
@@ -28,7 +28,6 @@ playsound minecraft:item.trident.throw block @a ~ ~ ~ 1 1.3
 scoreboard players set @s AXECOOLDOWN 60
 
 ##throw weapon
-#execute at @s anchored eyes positioned ^ ^ ^1.6 run summon spectral_arrow ~ ~ ~ {Tags:["New","ThrowAxe"],PierceLevel:99b,weapon:{id:"bow",components:{item_model:"nothing",enchantments:{"att2_enchantment:throw_axe":1}}},Passengers:[{id:"item_display",Tags:["New","ThrowAxe"],transformation:{scale:[1.0f,1.0f,1.0f],translation:[0.0f,0.0f,0.0f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,1.0f,0.0f,1.0f]},Passengers:[{id:"armor_stand",Tags:["New","ThrowAxe"],equipment:{mainhand:{id:"diamond",components:{enchantments:{"att2_enchantment:throw_axe":1}}}},attributes:[{id:scale,base:0.01}]}]}]}
 execute at @s anchored eyes positioned ^ ^ ^ run summon spectral_arrow ~ ~ ~ {Tags:["New","ThrowAxe"],SoundEvent:"intentionally_empty",LeftOwner:false,PierceLevel:99b,weapon:{id:"bow",components:{item_model:"nothing",enchantments:{"att2_enchantment:throw_axe":1}}},Passengers:[{id:"item_display",Tags:["New","ThrowAxe"],transformation:{scale:[1.0f,1.0f,1.0f],translation:[0.0f,-0.5f,0.0f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,0.71f,0.0f,0.71f]},brightness:{block:15,sky:15},Passengers:[{id:"armor_stand",Tags:["New","ThrowAxe"],equipment:{mainhand:{id:"diamond",components:{item_model:"nothing",enchantments:{"att2_enchantment:throw_axe":1}}}},attributes:[{id:scale,base:0.01}],Invisible:true,Marker:true}]}]}
 
 ##set base data
@@ -42,7 +41,7 @@ scoreboard players operation @n[distance=..5,type=item_display,tag=New] OWNER = 
 scoreboard players operation @n[distance=..5,type=armor_stand,tag=New] OWNER = @s NUMEROJOUEUR
 data modify entity @n[distance=..5,type=spectral_arrow,tag=New] Owner set from entity @s UUID
 ##store damage
-execute store result score @n[distance=..5,type=spectral_arrow,tag=New] STR_DATA run attribute @s attack_damage get
+execute store result score @n[distance=..5,type=spectral_arrow,tag=New] STR_DATA run attribute @s attack_damage base get
 ##sync rotation
 data modify entity 00000001-0000-006f-0000-00010000006f Rotation set from entity @s Rotation
 ##tp

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/marker_go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/marker_go.mcfunction
@@ -10,11 +10,12 @@
 function att2:gameplay/score/owner
 
 ##rotation
-execute as @s[tag=!Once] on vehicle run function att2:gameplay/equipment/weapon/axe/rotation
+execute on vehicle on vehicle if data entity @s {inGround:0b} on passengers run function att2:gameplay/equipment/weapon/axe/rotation
 ##return
 execute as @s[tag=Once,tag=!Return] positioned ~-1.5 ~-1.5 ~-1.5 if entity @p[dx=3,dy=3,dz=3,predicate=att2_pre:score/player] run function att2:gameplay/equipment/weapon/axe/return
 
 ##particle
+execute at @s[tag=Once] at @s positioned ~-0.5 ~-0.5 ~-0.5 if entity @n[dx=1,dy=1,dz=1,type=arrow,scores={OWNER=1..}] on vehicle on vehicle run function att2:gameplay/equipment/weapon/axe/move_detection
 execute at @s[tag=Once] run function att2:gameplay/equipment/weapon/axe/particle_throw_cycle
 execute at @s[tag=!Once] run function att2:gameplay/equipment/weapon/axe/particle/point
 ##if now have arrow

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/move_detection.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/move_detection.mcfunction
@@ -1,0 +1,56 @@
+#############################################################
+#Made by Adventquest						    			#
+#ham trigger
+#############################################################
+
+##summon arrow
+summon spectral_arrow ~ ~ ~ {Tags:["New","ThrowAxe","Once"],SoundEvent:"intentionally_empty",LeftOwner:false,PierceLevel:99b,weapon:{id:"bow",components:{item_model:"nothing",enchantments:{"att2_enchantment:throw_axe":1}}}}
+
+##sync data
+data modify entity @n[distance=..5,type=spectral_arrow,tag=New] Owner set from entity @s Owner
+data modify entity @n[distance=..5,type=spectral_arrow,tag=New] item set from entity @s item
+scoreboard players operation @n[distance=..5,type=spectral_arrow,tag=New] STR_DATA = @s STR_DATA
+##Rebound
+
+##get next facing
+execute as @n[dx=1,dy=1,dz=1,type=arrow,scores={OWNER=1..}] run function att2:gameplay/misc/motion/calculate/get_motion_direction
+kill @n[dx=1,dy=1,dz=1,type=arrow,scores={OWNER=1..}]
+execute store result score #Rotation0 CAL run data get storage att2:rotation temp[0]
+execute store result score #Rotation1 CAL run data get storage att2:rotation temp[1]
+
+scoreboard players add #Rotation0 CAL 180
+scoreboard players set 360 CAL 360
+scoreboard players operation #Rotation0 CAL %= 360 CAL
+execute if score #Rotation0 CAL matches 181.. run scoreboard players remove #Rotation0 CAL 360
+scoreboard players operation #Rotation1 CAL *= -1 CAL
+execute store result entity 00000001-0000-006f-0000-00010000006f Rotation[0] int 1 run scoreboard players get #Rotation0 CAL
+execute store result entity 00000001-0000-006f-0000-00010000006f Rotation[1] int 1 run scoreboard players get #Rotation1 CAL
+
+##tp
+#random spread
+execute store result score #RNG CAL run random value 1..4
+execute if score #RNG CAL matches 1 as 00000001-0000-006f-0000-00010000006f at @s run tp @s ^0.1 ^0.3 ^0.4
+execute if score #RNG CAL matches 2 as 00000001-0000-006f-0000-00010000006f at @s run tp @s ^-0.1 ^0.3 ^0.4
+execute if score #RNG CAL matches 3 as 00000001-0000-006f-0000-00010000006f at @s run tp @s ^-0.05 ^0.3 ^0.4
+execute if score #RNG CAL matches 4 as 00000001-0000-006f-0000-00010000006f at @s run tp @s ^0.05 ^0.3 ^0.4
+##return motion
+data modify entity @n[distance=..5,type=spectral_arrow,tag=New] Rotation set from entity 00000001-0000-006f-0000-00010000006f Rotation
+execute on passengers run data modify entity @s Rotation set from entity 00000001-0000-006f-0000-00010000006f Rotation
+
+execute as @n[distance=..5,type=spectral_arrow,tag=New] at @s run tp @s ^ ^ ^0.05
+data modify entity @n[distance=..5,type=spectral_arrow,tag=New] Motion set from entity 00000001-0000-006f-0000-00010000006f Pos
+data modify storage att2:test temp set from entity @s Motion
+execute in overworld run tp 00000001-0000-006f-0000-00010000006f 0.0 0.0 0.0
+
+
+##re rideS
+execute on passengers run tag @s add New
+execute on passengers run ride @s dismount
+ride @n[distance=..5,type=item_display,tag=New] mount @n[distance=..5,type=spectral_arrow,tag=New]
+##remove tag
+tag @e[distance=..5,type=spectral_arrow,tag=New] remove New
+tag @e[distance=..5,type=item_display,tag=New] remove New
+
+
+##clear
+kill @s[type=spectral_arrow]

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_copper.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_copper.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:copper_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:copper_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_diamond.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_diamond.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:diamond_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:diamond_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_golden.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_golden.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:golden_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:golden_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_iron.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_iron.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:iron_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:iron_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_netherite.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_netherite.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:netherite_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:netherite_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_stone.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_stone.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:stone_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:stone_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_wooden.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/particle_wooden.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:wooden_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:wooden_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/throw_hit_block_trigger.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/axe/throw_hit_block_trigger.mcfunction
@@ -10,7 +10,8 @@ function att2:gameplay/equipment/weapon/axe/damage_detection
 ##destroy
 execute if score #damage CAL >= #max_damage CAL run return run function att2:gameplay/equipment/weapon/axe/destroy
 
-
+##clear arrow
+kill @e[distance=0.1..1.5,type=#minecraft:arrows]
 particle minecraft:block_crumble{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
 particle minecraft:dust_pillar{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
 
@@ -25,7 +26,6 @@ playsound minecraft:item.trident.hit block @a ~ ~ ~ 1 2
 ##limit
 execute as @s[tag=Once] run return run function att2:gameplay/equipment/weapon/axe/land
 ##summon arrow
-#execute on passengers at @s run summon spectral_arrow ^ ^ ^ {Tags:["New","ThrowAxe","ThrowTrigger"],LeftOwner:false,PierceLevel:99b}
 summon spectral_arrow ~ ~ ~ {Tags:["New","ThrowAxe","Once"],SoundEvent:"intentionally_empty",LeftOwner:false,PierceLevel:99b,weapon:{id:"bow",components:{item_model:"nothing",enchantments:{"att2_enchantment:throw_axe":1}}}}
 
 ##sync data

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_copper.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_copper.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:copper_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:copper_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_diamond.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_diamond.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:diamond_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:diamond_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_golden.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_golden.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:golden_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:golden_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_iron.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_iron.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:iron_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:iron_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_netherite.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_netherite.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:netherite_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:netherite_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_stone.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_stone.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:stone_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:stone_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:stone_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:stone_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_wooden.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/ham/particle_wooden.mcfunction
@@ -3,6 +3,6 @@
 #ham trigger
 #############################################################
 
-particle minecraft:item{item:"minecraft:wooden_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:block_crumble{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
-particle minecraft:dust_pillar{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+particle minecraft:item{item:"minecraft:wooden_pickaxe"} ~ ~1 ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:block_crumble{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal
+particle minecraft:dust_pillar{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0.1 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/base_particle.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/base_particle.mcfunction
@@ -1,0 +1,21 @@
+#############################################################
+#Made by Adventquest						    			#
+#shield use trigger                                         #
+#############################################################
+
+particle minecraft:item{item:"minecraft:shield"} ~ ~1 ~ 1.5 1.5 1.5 0 50 normal
+particle minecraft:block_crumble{block_state:"minecraft:iron_block"} ~ ~1.5 ~ 1.5 1.5 1.5 0 50 normal
+particle minecraft:dust_pillar{block_state:"minecraft:iron_block"} ~ ~1.5 ~ 1.5 1.5 1.5 0 100 normal
+particle minecraft:block{block_state:"minecraft:iron_block"} ~ ~ ~ 1.5 1.5 1.5 1 50 normal
+particle minecraft:item{item:"minecraft:iron_block"} ~ ~ ~ 1.5 1.5 1.5 1 50 normal
+particle minecraft:dust_plume ~ ~ ~ 1.5 1.5 1.5 0.1 50 normal
+particle minecraft:campfire_cosy_smoke ~ ~ ~ 1.5 1.5 1.5 0.1 50 normal
+
+
+
+playsound minecraft:item.armor.equip_iron block @a ~ ~ ~ 1 1
+playsound minecraft:item.armor.equip_diamond block @a ~ ~ ~ 1 1.4
+playsound minecraft:unsheathe1 master @a ~ ~ ~ 1 2
+playsound minecraft:entity.player.attack.sweep master @a ~ ~ ~ 1 1.5
+#playsound minecraft:shield1 block @a ~ ~ ~ 1 1
+playsound minecraft:block.anvil.place block @a ~ ~ ~ 1 1

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/cooldown.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/cooldown.mcfunction
@@ -1,0 +1,9 @@
+#############################################################
+#Made by Adventquest						    			#
+#shield use trigger                                         #
+#############################################################
+
+##cooldown
+summon armor_stand ^ ^ ^3 {Marker:1,Invisible:1b,Tags:["New"],attributes:[{id:scale,base:0.1}],equipment:{mainhand:{id:diamond_axe,components:{item_model:"nothing"}}}}
+$damage @s $(damage) player_attack by @n[distance=..5,type=armor_stand,tag=New]
+kill @e[distance=..5,type=armor_stand,tag=New]

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/damage.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/damage.mcfunction
@@ -1,0 +1,18 @@
+#############################################################
+#Made by Adventquest						    			#
+#shield use trigger                                         #
+#############################################################
+
+##particle
+#particle minecraft:dust_pillar{block_state:"minecraft:redstone_block"} ~ ~ ~ 0.5 0.5 0.5 0.1 20 normal
+particle minecraft:dust_pillar{block_state:"minecraft:soul_sand"} ~ ~1 ~ 0.5 0.5 0.5 0.1 20 normal
+#particle minecraft:dust_pillar{block_state:"minecraft:nether_wart_block"} ~ ~ ~ 0.5 0.5 0.5 0.1 20 normal
+#particle minecraft:block{block_state:"minecraft:redstone_block"} ~ ~1 ~ 0.5 0.5 0.5 0.1 40 normal
+#particle minecraft:dust{color:[1,0,0],scale:1.0} ~ ~1 ~ 0.5 0.5 0.5 0.1 40 normal
+
+particle minecraft:item{item:"minecraft:shield"} ~ ~1 ~ 0.5 0.5 0.5 0.1 20 normal
+
+##damage
+$damage @s $(value) att2_damage:player_attack by @p[predicate=att2_pre:score/player]
+##detection health
+function att2:gameplay/enemy_health/melee_health_trigger

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/hand_launch.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/hand_launch.mcfunction
@@ -8,7 +8,7 @@
 #execute at @s anchored eyes positioned ^ ^ ^3 unless entity @e[distance=..3,team=hostile,scores={GAMELEVEL=0..}] run return fail
 #update cooldown
 summon armor_stand ^ ^ ^3 {Marker:1,Invisible:1b,Tags:["New"],attributes:[{id:scale,base:0.1}],equipment:{mainhand:{id:diamond_axe,components:{item_model:"nothing"}}}}
-damage @s 12 player_attack by @n[distance=..5,type=armor_stand,tag=New]
+damage @s 16 player_attack by @n[distance=..5,type=armor_stand,tag=New]
 kill @e[distance=..5,type=armor_stand,tag=New]
 
 
@@ -18,13 +18,19 @@ kill @e[distance=..5,type=armor_stand,tag=New]
 #get pos
 summon marker ~ ~ ~ {Tags:["Temp"]}
 ##effect enemy
-execute as @e[distance=..4,team=hostile,scores={GAMELEVEL=0..}] at @s run function att2:gameplay/equipment/weapon/shield/motion
+execute at @s positioned ~-2 ~-2 ~-2 as @e[dx=4,dy=4,dz=4,team=hostile,scores={GAMELEVEL=0..}] at @s run function att2:gameplay/equipment/weapon/shield/motion
 #clear
 kill @e[distance=..10,type=marker,tag=Temp]
 
 particle minecraft:item{item:"minecraft:shield"} ~ ~1 ~ 1.5 1.5 1.5 0 50 normal
-particle minecraft:block_crumble{block_state:"minecraft:iron_block"} ~ ~ ~ 1.5 1.5 1.5 0 50 normal
-particle minecraft:dust_pillar{block_state:"minecraft:iron_block"} ~ ~ ~ 1.5 1.5 1.5 0 50 normal
+particle minecraft:block_crumble{block_state:"minecraft:iron_block"} ~ ~1.5 ~ 1.5 1.5 1.5 0 50 normal
+particle minecraft:dust_pillar{block_state:"minecraft:iron_block"} ~ ~1.5 ~ 1.5 1.5 1.5 0 100 normal
+particle minecraft:block{block_state:"minecraft:iron_block"} ~ ~ ~ 1.5 1.5 1.5 1 50 normal
+particle minecraft:item{item:"minecraft:iron_block"} ~ ~ ~ 1.5 1.5 1.5 1 50 normal
+particle minecraft:dust_plume ~ ~ ~ 1.5 1.5 1.5 0.1 50 normal
+particle minecraft:campfire_cosy_smoke ~ ~ ~ 1.5 1.5 1.5 0.1 50 normal
+
+
 
 playsound minecraft:item.armor.equip_iron block @a ~ ~ ~ 1 1
 playsound minecraft:item.armor.equip_diamond block @a ~ ~ ~ 1 1.4
@@ -32,21 +38,3 @@ playsound minecraft:unsheathe1 master @a ~ ~ ~ 1 2
 playsound minecraft:entity.player.attack.sweep master @a ~ ~ ~ 1 1.5
 #playsound minecraft:shield1 block @a ~ ~ ~ 1 1
 playsound minecraft:block.anvil.place block @a ~ ~ ~ 1 1
-
-
-particle minecraft:sweep_attack ~ ~1.6 ~2 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~0.8 ~1.6 ~1.8 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~1.4 ~1.6 ~1.4 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~1.8 ~1.6 ~0.8 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~2 ~1.6 ~0 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~1.8 ~1.6 ~-0.8 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~1.4 ~1.6 ~-1.4 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~0.8 ~1.6 ~-1.8 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~0 ~1.6 ~-2 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~-0.8 ~1.6 ~-1.8 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~-1.4 ~1.6 ~-1.4 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~-1.8 ~1.6 ~-0.8 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~-2 ~1.6 ~0 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~-1.8 ~1.6 ~0.8 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~-1.4 ~1.6 ~1.4 0.1 0.5 0.1 0 3 force
-particle minecraft:sweep_attack ~-0.8 ~1.6 ~1.8 0.1 0.5 0.1 0 3 force

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/axe.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/axe.mcfunction
@@ -1,0 +1,25 @@
+#############################################################
+#Made by Adventquest						    			#
+#shield use trigger                                         #
+#############################################################
+
+##base particle
+function att2:gameplay/equipment/weapon/shield/base_particle
+
+##cooldown/remove durability : 10 = 20/2
+function att2:gameplay/equipment/weapon/shield/cooldown {damage:20}
+##consume hunger
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/misc/satiety_consume":30}}
+
+##Dizziness
+scoreboard players set #time Dizziness 30
+execute at @s positioned ~-2 ~-2 ~-2 as @e[dx=4,dy=4,dz=4,team=hostile,scores={GAMELEVEL=0..}] at @s run function att2:gameplay/speceffect/dizziness/trigger
+
+###############motion
+#get pos
+summon marker ~ ~ ~ {Tags:["Temp"]}
+##effect enemy
+execute at @s positioned ~-2 ~-2 ~-2 as @e[dx=4,dy=4,dz=4,team=hostile,scores={GAMELEVEL=0..}] at @s run function att2:gameplay/equipment/weapon/shield/motion
+#clear
+kill @e[distance=..10,type=marker,tag=Temp]
+##--------------------------------

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/dagger.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/dagger.mcfunction
@@ -1,0 +1,36 @@
+#############################################################
+#Made by Adventquest						    			#
+#shield use trigger                                         #
+#############################################################
+
+
+##limit
+execute unless predicate att2_pre:player/onground run return fail
+execute if predicate att2_pre:player/in_water run return fail
+execute if predicate att2_pre:player/flying run return fail
+
+
+##base particle
+function att2:gameplay/equipment/weapon/shield/base_particle
+
+##cooldown/remove durability : 15 = 30/2
+function att2:gameplay/equipment/weapon/shield/cooldown {damage:30}
+##consume hunger
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/misc/satiety_consume":20}}
+
+##motion
+function att2:gameplay/misc/motion/reset
+execute unless items entity @s saddle diamond run item replace entity @s saddle with diamond[equippable={slot:saddle,equip_sound:intentionally_empty}]
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/motion/up":5}}
+
+##invulnerable time
+scoreboard players set @s Invulnerable 15
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/misc/invulnerable":1}}
+
+
+
+execute if predicate att2_pre:player/input/w run return run item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/motion/w":6}}
+execute if predicate att2_pre:player/input/a run return run item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/motion/a":6}}
+execute if predicate att2_pre:player/input/s run return run item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/motion/s":6}}
+execute if predicate att2_pre:player/input/d run return run item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/motion/d":6}}
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/motion/w":6}}

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/hand.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/hand.mcfunction
@@ -1,0 +1,22 @@
+#############################################################
+#Made by Adventquest						    			#
+#shield use trigger                                         #
+#############################################################
+
+##base particle
+function att2:gameplay/equipment/weapon/shield/base_particle
+
+
+##cooldown/remove durability : 5 = 10/2
+function att2:gameplay/equipment/weapon/shield/cooldown {damage:10}
+##consume hunger
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/misc/satiety_consume":5}}
+
+###############motion
+#get pos
+summon marker ~ ~ ~ {Tags:["Temp"]}
+##effect enemy
+execute at @s positioned ~-2 ~-2 ~-2 as @e[dx=4,dy=4,dz=4,team=hostile,scores={GAMELEVEL=0..}] at @s run function att2:gameplay/equipment/weapon/shield/motion
+#clear
+kill @e[distance=..10,type=marker,tag=Temp]
+##--------------------------------

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/pickaxe.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/pickaxe.mcfunction
@@ -3,13 +3,20 @@
 #shield use trigger                                         #
 #############################################################
 
-##normal launch
-function att2:gameplay/equipment/weapon/shield/hand_launch
 
 ##limit
 execute unless predicate att2_pre:player/onground run return fail
 execute if predicate att2_pre:player/in_water run return fail
 execute if predicate att2_pre:player/flying run return fail
+
+
+##base particle
+function att2:gameplay/equipment/weapon/shield/base_particle
+
+##cooldown/remove durability : 15 = 30/2
+function att2:gameplay/equipment/weapon/shield/cooldown {damage:30}
+##consume hunger
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/misc/satiety_consume":20}}
 
 ##motion
 function att2:gameplay/misc/motion/reset

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/sword.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch/sword.mcfunction
@@ -1,0 +1,48 @@
+#############################################################
+#Made by Adventquest						    			#
+#shield use trigger                                         #
+#############################################################
+
+##base particle
+function att2:gameplay/equipment/weapon/shield/base_particle
+
+##cooldown/remove durability : 7 = 14/2
+function att2:gameplay/equipment/weapon/shield/cooldown {damage:14}
+
+##consume hunger
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/misc/satiety_consume":10}}
+###############motion
+#get pos
+summon marker ~ ~ ~ {Tags:["Temp"]}
+##effect enemy
+execute at @s positioned ~-3 ~-3 ~-3 as @e[dx=6,dy=6,dz=6,team=hostile,scores={GAMELEVEL=0..}] at @s run function att2:gameplay/equipment/weapon/shield/motion
+#clear
+kill @e[distance=..10,type=marker,tag=Temp]
+##--------------------------------
+
+##get damage data
+execute store result score #damage CAL run attribute @s attack_damage base get 0.6
+execute store result storage att2:damage value int 1 run scoreboard players get #damage CAL
+function att2:gameplay/score/player
+
+##damage
+execute at @s positioned ~-3 ~-3 ~-3 as @e[dx=6,dy=6,dz=6,team=hostile,scores={GAMELEVEL=0..}] at @s run function att2:gameplay/equipment/weapon/shield/damage with storage att2:damage
+
+
+##more particle
+particle minecraft:sweep_attack ~ ~1.6 ~2 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~0.8 ~1.6 ~1.8 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~1.4 ~1.6 ~1.4 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~1.8 ~1.6 ~0.8 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~2 ~1.6 ~0 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~1.8 ~1.6 ~-0.8 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~1.4 ~1.6 ~-1.4 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~0.8 ~1.6 ~-1.8 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~0 ~1.6 ~-2 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~-0.8 ~1.6 ~-1.8 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~-1.4 ~1.6 ~-1.4 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~-1.8 ~1.6 ~-0.8 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~-2 ~1.6 ~0 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~-1.8 ~1.6 ~0.8 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~-1.4 ~1.6 ~1.4 0.1 0.5 0.1 0 3 force
+particle minecraft:sweep_attack ~-0.8 ~1.6 ~1.8 0.1 0.5 0.1 0 3 force

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch_detection.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/launch_detection.mcfunction
@@ -5,9 +5,12 @@
 
 ##limit
 ##
-execute if items entity @s weapon.mainhand #minecraft:pickaxes run return run function att2:gameplay/equipment/weapon/shield/pickaxe_launch
+execute if items entity @s weapon.mainhand #minecraft:pickaxes run return run function att2:gameplay/equipment/weapon/shield/launch/pickaxe
+execute if items entity @s weapon.mainhand #minecraft:swords run return run function att2:gameplay/equipment/weapon/shield/launch/sword
+execute if items entity @s weapon.mainhand #minecraft:axes run return run function att2:gameplay/equipment/weapon/shield/launch/axe
+execute if items entity @s weapon.mainhand #minecraft:shovels run return run function att2:gameplay/equipment/weapon/shield/launch/dagger
 
 
 
 ##end
-function att2:gameplay/equipment/weapon/shield/hand_launch
+function att2:gameplay/equipment/weapon/shield/launch/hand

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/motion.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/motion.mcfunction
@@ -8,7 +8,8 @@ rotate @n[distance=..10,type=marker,tag=Temp] facing entity @s eyes
 ##sync rotation
 data modify entity 00000001-0000-006f-0000-00010000006f Rotation set from entity @n[distance=..10,type=marker,tag=Temp] Rotation
 ##tp
-execute as 00000001-0000-006f-0000-00010000006f at @s run tp @s ^ ^0.1 ^0.7
+execute as 00000001-0000-006f-0000-00010000006f at @s run rotate @s ~ -45
+execute as 00000001-0000-006f-0000-00010000006f at @s run tp @s ^ ^ ^0.7
 ##return motion
 data modify entity @s Motion set from entity 00000001-0000-006f-0000-00010000006f Pos
 execute in overworld run tp 00000001-0000-006f-0000-00010000006f 0.0 0.0 0.0

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/replace_hand.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/shield/replace_hand.mcfunction
@@ -3,17 +3,15 @@
 #shield use trigger                                         #
 #############################################################
 
-#
-execute if items entity @s weapon.mainhand shield run item replace block 0 0 0 container.0 from entity @s weapon.mainhand 
-execute if items entity @s weapon.offhand shield run item replace block 0 0 0 container.1 from entity @s weapon.offhand
-
-##replace
-execute if items entity @s weapon.mainhand shield run item replace entity @s weapon.mainhand with shield[item_model="nothing"]
-execute if items entity @s weapon.offhand shield run item replace entity @s weapon.offhand with shield[item_model="nothing"]
+##temp block
+item replace block 0 0 0 container.0 from entity @s weapon.offhand
+#replace mainhand -> offhand 
+item replace entity @s weapon.offhand from entity @s weapon.mainhand
+item replace entity @s weapon.mainhand from block 0 0 0 container.0
 
 ##return
-execute if items entity @s weapon.mainhand shield[item_model="nothing"] run item replace entity @s weapon.mainhand from block 0 0 0 container.0 {function:set_components,components:{"minecraft:consumable":{"animation":"block","consume_seconds":3.0,"has_consume_particles":false,"sound":{"sound_id":""}}}}
-execute if items entity @s weapon.offhand shield[item_model="nothing"] run item replace entity @s weapon.offhand from block 0 0 0 container.1 {function:set_components,components:{"minecraft:consumable":{"animation":"block","consume_seconds":3.0,"has_consume_particles":false,"sound":{"sound_id":""}}}}
+#execute if items entity @s weapon.mainhand shield[item_model="nothing"] run item replace entity @s weapon.mainhand from block 0 0 0 container.0 {function:set_components,components:{"minecraft:consumable":{"animation":"block","consume_seconds":3.0,"has_consume_particles":false,"sound":{"sound_id":""}}}}
+#execute if items entity @s weapon.offhand shield[item_model="nothing"] run item replace entity @s weapon.offhand from block 0 0 0 container.1 {function:set_components,components:{"minecraft:consumable":{"animation":"block","consume_seconds":3.0,"has_consume_particles":false,"sound":{"sound_id":""}}}}
 
 playsound minecraft:item.armor.equip_iron block @a ~ ~ ~ 1 1
 playsound minecraft:item.armor.equip_diamond block @a ~ ~ ~ 1 1.4

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_copper.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_copper.mcfunction
@@ -1,0 +1,8 @@
+#############################################################
+#Made by Adventquest						    			#
+#ham trigger
+#############################################################
+
+particle minecraft:item{item:"minecraft:copper_sword"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:block_crumble{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:dust_pillar{block_state:"minecraft:copper_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_diamond.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_diamond.mcfunction
@@ -1,0 +1,8 @@
+#############################################################
+#Made by Adventquest						    			#
+#ham trigger
+#############################################################
+
+execute at @s anchored eyes positioned ^ ^ ^1.6 run particle minecraft:item{item:"minecraft:diamond_sword"} ^ ^ ^ 0.5 0.5 0.5 0.1 40 normal
+#particle minecraft:block_crumble{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:dust_pillar{block_state:"minecraft:diamond_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_golden.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_golden.mcfunction
@@ -1,0 +1,8 @@
+#############################################################
+#Made by Adventquest						    			#
+#ham trigger
+#############################################################
+
+particle minecraft:item{item:"minecraft:golden_sword"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:block_crumble{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:dust_pillar{block_state:"minecraft:golden_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_iron.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_iron.mcfunction
@@ -1,0 +1,8 @@
+#############################################################
+#Made by Adventquest						    			#
+#ham trigger
+#############################################################
+
+particle minecraft:item{item:"minecraft:iron_sword"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:block_crumble{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:dust_pillar{block_state:"minecraft:iron_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_netherite.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_netherite.mcfunction
@@ -1,0 +1,8 @@
+#############################################################
+#Made by Adventquest						    			#
+#ham trigger
+#############################################################
+
+particle minecraft:item{item:"minecraft:netherite_sword"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:block_crumble{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:dust_pillar{block_state:"minecraft:netherite_block"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_stone.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_stone.mcfunction
@@ -1,0 +1,8 @@
+#############################################################
+#Made by Adventquest						    			#
+#ham trigger
+#############################################################
+
+particle minecraft:item{item:"minecraft:stone_sword"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:block_crumble{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:dust_pillar{block_state:"minecraft:stone"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_wooden.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/particle_wooden.mcfunction
@@ -1,0 +1,8 @@
+#############################################################
+#Made by Adventquest						    			#
+#ham trigger
+#############################################################
+
+particle minecraft:item{item:"minecraft:wooden_sword"} ~ ~1 ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:block_crumble{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal
+#particle minecraft:dust_pillar{block_state:"minecraft:oak_log"} ~ ~ ~ 0.7 0.7 0.7 0 40 normal

--- a/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/trigger.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/equipment/weapon/sword/trigger.mcfunction
@@ -1,21 +1,22 @@
 #############################################################
 #Made by Adventquest						    			#
-#ham trigger
+#sword trigger
 #############################################################
 
-##add score
-scoreboard players add @s DAGGER_TIME 40
 ##limit
-scoreboard players set @s[scores={DAGGER_TIME=150..}] DAGGER_TIME 150
+#scoreboard players set @s[scores={DAGGER_TIME=150..}] DAGGER_TIME 150
 
-execute if items entity @s[scores={DAGGER_TIME=100..}] weapon.mainhand #minecraft:shovels run item modify entity @s weapon.mainhand {function:set_components,components:{minimum_attack_charge:0.8,swing_animation:{type:stab}}}
-execute if items entity @s[scores={DAGGER_TIME=100..}] weapon.offhand #minecraft:shovels in overworld run function att2:gameplay/equipment/weapon/dagger/replace_hand
+#execute if items entity @s[scores={DAGGER_TIME=100..}] weapon.mainhand #minecraft:shovels run item modify entity @s weapon.mainhand {function:set_components,components:{minimum_attack_charge:0.8,swing_animation:{type:stab}}}
+#execute if items entity @s[scores={DAGGER_TIME=100..}] weapon.offhand #minecraft:shovels in overworld run function att2:gameplay/equipment/weapon/dagger/replace_hand
 
 ##particle
-execute if items entity @s weapon.mainhand minecraft:wooden_shovel run return run function att2:gameplay/equipment/ham/particle_wooden
-execute if items entity @s weapon.mainhand minecraft:stone_shovel run return run function att2:gameplay/equipment/ham/particle_stone
-execute if items entity @s weapon.mainhand minecraft:copper_shovel run return run function att2:gameplay/equipment/ham/particle_copper
-execute if items entity @s weapon.mainhand minecraft:iron_shovel run return run function att2:gameplay/equipment/ham/particle_iron
-execute if items entity @s weapon.mainhand minecraft:golden_shovel run return run function att2:gameplay/equipment/ham/particle_golden
-execute if items entity @s weapon.mainhand minecraft:diamond_shovel run return run function att2:gameplay/equipment/ham/particle_diamond
-execute if items entity @s weapon.mainhand minecraft:netherite_shovel run return run function att2:gameplay/equipment/ham/particle_netherite
+execute at @s anchored eyes run particle minecraft:sweep_attack ^ ^-0.4 ^1.2 0 0 0 0.1 1 force
+
+##particle
+execute if items entity @s weapon.mainhand minecraft:wooden_sword run return run function att2:gameplay/equipment/weapon/sword/particle_wooden
+execute if items entity @s weapon.mainhand minecraft:stone_sword run return run function att2:gameplay/equipment/weapon/sword/particle_stone
+execute if items entity @s weapon.mainhand minecraft:copper_sword run return run function att2:gameplay/equipment/weapon/sword/particle_copper
+execute if items entity @s weapon.mainhand minecraft:iron_sword run return run function att2:gameplay/equipment/weapon/sword/particle_iron
+execute if items entity @s weapon.mainhand minecraft:golden_sword run return run function att2:gameplay/equipment/weapon/sword/particle_golden
+execute if items entity @s weapon.mainhand minecraft:diamond_sword run return run function att2:gameplay/equipment/weapon/sword/particle_diamond
+execute if items entity @s weapon.mainhand minecraft:netherite_sword run return run function att2:gameplay/equipment/weapon/sword/particle_netherite

--- a/adventquest_function/data/att2/function/gameplay/leveling/monster/initialize/initnewmonster.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/leveling/monster/initialize/initnewmonster.mcfunction
@@ -15,7 +15,6 @@ execute if data entity @s drop_chances if items entity @s armor.head diamond_hel
 
 ##Add damage detection trigger.
 item modify entity @s[type=!minecraft:bat] armor.head {function:set_enchantments,enchantments:{"att2_enchantment:tick/mob_tick":1}}
-
 ##prevent Drowning
 effect give @s water_breathing infinite 0 true
 effect give @s fire_resistance infinite 0 true

--- a/adventquest_function/data/att2/function/gameplay/leveling/monster/shield_enemy/block_trigger.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/leveling/monster/shield_enemy/block_trigger.mcfunction
@@ -1,0 +1,29 @@
+#########################################################
+#Made by adventquest									#
+#shield enemy block trigger
+#########################################################
+
+#test front
+execute at @s anchored eyes positioned ^ ^ ^3 on attacker unless entity @s[distance=..3] run return fail
+
+
+##remove percent damage
+scoreboard players operation #reduce_health CAL *= 50 CAL
+scoreboard players operation #reduce_health CAL /= 100 CAL
+
+##remove durability
+execute unless items entity @s weapon.offhand shield[custom_data~{Shield:true}] run item modify entity @s weapon.offhand [{function:set_custom_data,tag:{"Shield":true}},{function:set_components,components:{"minecraft:damage":0,"minecraft:max_damage":100}}]
+
+##remove
+execute on attacker if items entity @s weapon.mainhand #minecraft:axes run scoreboard players set #count CAL 30
+execute on attacker if items entity @s weapon.mainhand #minecraft:swords run scoreboard players set #count CAL 15
+execute on attacker if items entity @s weapon.mainhand #minecraft:shovels run scoreboard players set #count CAL 10
+execute on attacker if items entity @s weapon.mainhand #minecraft:pickaxes run scoreboard players set #count CAL 25
+execute on attacker if items entity @s weapon.mainhand #minecraft:spears run scoreboard players set #count CAL 15
+execute on attacker if items entity @s weapon.mainhand #minecraft:hoes run scoreboard players set #count CAL 20
+function att2:gameplay/misc/durability/add_offhand
+##destroy 
+execute if score #damage CAL = #max_damage CAL at @s anchored eyes positioned ^ ^ ^0.5 run function att2:gameplay/leveling/monster/shield_enemy/destroy
+
+##effect
+execute at @s anchored eyes positioned ^ ^ ^1 run function att2:gameplay/leveling/monster/shield_enemy/particle

--- a/adventquest_function/data/att2/function/gameplay/leveling/monster/shield_enemy/block_trigger.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/leveling/monster/shield_enemy/block_trigger.mcfunction
@@ -4,23 +4,24 @@
 #########################################################
 
 #test front
-execute at @s anchored eyes positioned ^ ^ ^3 on attacker unless entity @s[distance=..3] run return fail
+execute at @s anchored eyes positioned ^ ^ ^4 positioned ~-2 ~-2 ~-2 on attacker unless entity @s[dx=4,dy=4,dz=4] run return fail
 
 
 ##remove percent damage
 scoreboard players operation #reduce_health CAL *= 50 CAL
 scoreboard players operation #reduce_health CAL /= 100 CAL
-
+scoreboard players operation #reduce_health CAL > 1 CAL
 ##remove durability
 execute unless items entity @s weapon.offhand shield[custom_data~{Shield:true}] run item modify entity @s weapon.offhand [{function:set_custom_data,tag:{"Shield":true}},{function:set_components,components:{"minecraft:damage":0,"minecraft:max_damage":100}}]
 
 ##remove
-execute on attacker if items entity @s weapon.mainhand #minecraft:axes run scoreboard players set #count CAL 30
-execute on attacker if items entity @s weapon.mainhand #minecraft:swords run scoreboard players set #count CAL 15
-execute on attacker if items entity @s weapon.mainhand #minecraft:shovels run scoreboard players set #count CAL 10
-execute on attacker if items entity @s weapon.mainhand #minecraft:pickaxes run scoreboard players set #count CAL 25
-execute on attacker if items entity @s weapon.mainhand #minecraft:spears run scoreboard players set #count CAL 15
-execute on attacker if items entity @s weapon.mainhand #minecraft:hoes run scoreboard players set #count CAL 20
+execute on attacker if items entity @s weapon.mainhand #minecraft:axes run scoreboard players set #count CAL 20
+execute on attacker if items entity @s weapon.mainhand #minecraft:swords run scoreboard players set #count CAL 8
+execute on attacker if items entity @s weapon.mainhand #minecraft:shovels run scoreboard players set #count CAL 5
+execute on attacker if items entity @s weapon.mainhand #minecraft:pickaxes run scoreboard players set #count CAL 15
+execute on attacker if items entity @s weapon.mainhand #minecraft:spears run scoreboard players set #count CAL 10
+execute on attacker if items entity @s weapon.mainhand #minecraft:hoes run scoreboard players set #count CAL 6
+execute on attacker unless items entity @s weapon.mainhand * run scoreboard players set #count CAL 1
 function att2:gameplay/misc/durability/add_offhand
 ##destroy 
 execute if score #damage CAL = #max_damage CAL at @s anchored eyes positioned ^ ^ ^0.5 run function att2:gameplay/leveling/monster/shield_enemy/destroy

--- a/adventquest_function/data/att2/function/gameplay/leveling/monster/shield_enemy/destroy.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/leveling/monster/shield_enemy/destroy.mcfunction
@@ -1,0 +1,20 @@
+#########################################################
+#Made by adventquest									#
+#shield enemy block trigger
+#########################################################
+
+
+##remove shield
+item replace entity @s weapon.offhand with air
+
+##particle
+particle minecraft:item{item:"minecraft:shield"} ~ ~ ~ 0.5 0.5 0.5 0.1 100 normal
+particle minecraft:item{item:"minecraft:iron_block"} ~ ~ ~ 1.5 1.5 1.5 1 50 normal
+particle minecraft:dust_plume ~ ~ ~ 1.5 1.5 1.5 0.1 50 normal
+
+
+##sound
+playsound minecraft:item.armor.equip_iron block @a ~ ~ ~ 1 1
+playsound minecraft:item.armor.equip_diamond block @a ~ ~ ~ 1 1.4
+playsound minecraft:item.shield.break block @a ~ ~ ~ 1 1
+playsound minecraft:item.shield.break block @a ~ ~ ~ 1 1

--- a/adventquest_function/data/att2/function/gameplay/leveling/monster/shield_enemy/particle.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/leveling/monster/shield_enemy/particle.mcfunction
@@ -1,0 +1,19 @@
+#########################################################
+#Made by adventquest									#
+#shield enemy block trigger
+#########################################################
+
+##particle
+particle minecraft:item{item:"minecraft:shield"} ~ ~ ~ 1 1 1 0.1 50 normal
+particle minecraft:item{item:"minecraft:iron_block"} ~ ~ ~ 1 1 1 1 50 normal
+particle minecraft:dust_plume ~ ~ ~ 1 1 1 0.1 50 normal
+
+
+##sound
+playsound minecraft:item.armor.equip_iron block @a ~ ~ ~ 1 1
+playsound minecraft:item.armor.equip_diamond block @a ~ ~ ~ 1 1.4
+playsound minecraft:item.shield.block master @a ~ ~ ~ 1 2
+playsound minecraft:item.shield.block master @a ~ ~ ~ 1 1
+playsound minecraft:entity.player.attack.sweep master @a ~ ~ ~ 1 1.5
+#playsound minecraft:shield1 block @a ~ ~ ~ 1 1
+playsound minecraft:block.anvil.place block @a ~ ~ ~ 1 1

--- a/adventquest_function/data/att2/function/gameplay/misc/durability/add_mainhand.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/misc/durability/add_mainhand.mcfunction
@@ -1,0 +1,21 @@
+#################################################################
+#Made by Adventquest											#
+#add_mainhand
+#################################################################
+
+##store temp
+execute in overworld run item replace block 0 0 0 container.0 from entity @s weapon.mainhand
+
+##get damage/max_damage
+execute in overworld store result score #damage CAL run data get block 0 0 0 Items[{Slot:0b}].components."minecraft:damage"
+execute in overworld store result score #max_damage CAL run data get block 0 0 0 Items[{Slot:0b}].components."minecraft:max_damage"
+
+##remove score
+scoreboard players operation #damage CAL += #count CAL
+scoreboard players operation #damage CAL < #max_damage CAL
+#tellraw @a [{score:{name:"#damage",objective:"CAL"}}]
+#tellraw @a [{score:{name:"#max_damage",objective:"CAL"}}]
+
+execute in overworld store result block 0 0 0 Items[{Slot:0b}].components."minecraft:damage" int 1 run scoreboard players get #damage CAL
+##return
+execute in overworld run item replace entity @s weapon.mainhand from block 0 0 0 container.0

--- a/adventquest_function/data/att2/function/gameplay/misc/durability/add_offhand.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/misc/durability/add_offhand.mcfunction
@@ -1,0 +1,19 @@
+#################################################################
+#Made by Adventquest											#
+#ender chest                                                    #
+#################################################################
+
+##store temp
+execute in overworld run item replace block 0 0 0 container.0 from entity @s weapon.offhand
+
+##get damage/max_damage
+execute in overworld store result score #damage CAL run data get block 0 0 0 Items[{Slot:0b}].components."minecraft:damage"
+execute in overworld store result score #max_damage CAL run data get block 0 0 0 Items[{Slot:0b}].components."minecraft:max_damage"
+
+##remove score
+scoreboard players operation #damage CAL += #count CAL
+scoreboard players operation #damage CAL < #max_damage CAL
+
+execute in overworld store result block 0 0 0 Items[{Slot:0b}].components."minecraft:damage" int 1 run scoreboard players get #damage CAL
+##return
+execute in overworld run item replace entity @s weapon.offhand from block 0 0 0 container.0

--- a/adventquest_function/data/att2/function/gameplay/misc/durability/percent_mainhand.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/misc/durability/percent_mainhand.mcfunction
@@ -1,0 +1,18 @@
+#################################################################
+#Made by Adventquest											#
+#Disabled the tips assist auto 								    #
+#################################################################
+
+##store temp
+execute in overworld run item replace block 0 0 0 container.0 from entity @s weapon.mainhand
+
+##get damage/max_damage
+execute in overworld store result score #damage CAL run data get block 0 0 0 Items[{Slot:0b}].components."minecraft:max_damage"
+
+##remove score
+scoreboard players operation #damage CAL *= #count CAL
+scoreboard players operation #damage CAL /= 100 CAL
+
+execute in overworld store result block 0 0 0 Items[{Slot:0b}].components."minecraft:damage" int 1 run scoreboard players get #damage CAL
+##return
+execute in overworld run item replace entity @s weapon.mainhand from block 0 0 0 container.0

--- a/adventquest_function/data/att2/function/gameplay/misc/durability/percent_offhand.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/misc/durability/percent_offhand.mcfunction
@@ -1,0 +1,18 @@
+#################################################################
+#Made by Adventquest											#
+#Disabled the tips assist auto 								    #
+#################################################################
+
+##store temp
+execute in overworld run item replace block 0 0 0 container.0 from entity @s weapon.offhand
+
+##get damage/max_damage
+execute in overworld store result score #damage CAL run data get block 0 0 0 Items[{Slot:0b}].components."minecraft:max_damage"
+
+##remove score
+scoreboard players operation #damage CAL *= #count CAL
+scoreboard players operation #damage CAL /= 100 CAL
+
+execute in overworld store result block 0 0 0 Items[{Slot:0b}].components."minecraft:damage" int 1 run scoreboard players get #damage CAL
+##return
+execute in overworld run item replace entity @s weapon.offhand from block 0 0 0 container.0

--- a/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/initialize.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/initialize.mcfunction
@@ -1,0 +1,7 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize speceffect for a given player						#
+#################################################################
+
+#
+scoreboard objectives add Dizziness dummy

--- a/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/other_go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/other_go.mcfunction
@@ -1,0 +1,15 @@
+#################################################################
+#Made by Adventquest											#
+#Process all special effect operation							#
+#################################################################
+
+##limit
+
+##tip
+execute at @s anchored eyes positioned ^ ^ ^ run function att2:gameplay/speceffect/dizziness/particle
+##remove time
+execute unless score @s Dizziness matches ..0 run return run scoreboard players remove @s Dizziness 1
+
+##clear
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/special_effect/dizziness":0}}
+scoreboard players reset @s Dizziness

--- a/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/particle.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/particle.mcfunction
@@ -1,0 +1,7 @@
+#################################################################
+#Made by Adventquest											#
+#Process all special effect operation							#
+#################################################################
+
+particle entity_effect{color:[0.67, 0.71, 0.7, 1]} ~ ~ ~ 0 0 0 0 10 normal
+particle falling_nectar ~ ~ ~ 0.5 0.5 0.5 0.1 10 normal

--- a/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/player_go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/player_go.mcfunction
@@ -1,0 +1,17 @@
+#################################################################
+#Made by Adventquest											#
+#Process all special effect operation							#
+#################################################################
+
+##limit
+
+
+execute at @s anchored eyes positioned ^ ^ ^ run function att2:gameplay/speceffect/dizziness/particle
+##remove time
+execute unless score @s Dizziness matches ..0 run return run scoreboard players remove @s Dizziness 1
+
+
+##clear
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/special_effect/dizziness":0}}
+
+scoreboard players reset @s Dizziness

--- a/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/test.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/test.mcfunction
@@ -1,0 +1,10 @@
+#################################################################
+#Made by Adventquest											#
+#Process all special effect operation							#
+#################################################################
+
+#
+execute unless items entity @s saddle * run item replace entity @s saddle with saddle[equippable={slot:saddle,equip_sound:intentionally_empty}]
+##clear
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/special_effect/dizziness":1}}
+scoreboard players set @s Dizziness 20

--- a/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/trigger.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/speceffect/dizziness/trigger.mcfunction
@@ -1,0 +1,14 @@
+#################################################################
+#Made by Adventquest											#
+#Process all special effect operation							#
+#################################################################
+
+#
+execute unless items entity @s saddle * run item replace entity @s saddle with saddle[equippable={slot:saddle,equip_sound:intentionally_empty}]
+##clear
+item modify entity @s saddle {function:set_enchantments,enchantments:{"att2_enchantment:tick/special_effect/dizziness":1}}
+
+scoreboard players operation @s Dizziness = #time Dizziness
+##if boss
+scoreboard players operation @s[tag=BOSS] Dizziness *= 50 CAL
+scoreboard players operation @s[tag=BOSS] Dizziness /= 100 CAL

--- a/adventquest_function/data/att2/function/gameplay/speceffect/initialize.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/speceffect/initialize.mcfunction
@@ -7,3 +7,4 @@ function att2:gameplay/speceffect/black_fading/initialize
 function att2:gameplay/speceffect/shaking/initialize
 function att2:gameplay/speceffect/random/initialize
 function att2:gameplay/speceffect/disincarnate/initialize
+function att2:gameplay/speceffect/dizziness/initialize


### PR DESCRIPTION

When a player deals damage to a "shield-wielding enemy" within a 4-meter range in front of them, the melee damage received by the "shield-wielding enemy" is reduced by 70%. Using different weapons can reduce the shield durability of the "shield-wielding enemy," with axes significantly decreasing the shield durability of the "shield-wielding enemy."

