### PR TITLE
Convert all boss bar texts into translation keys.

### DIFF
--- a/adventquest_function/data/att2/dialog/consciousness/guide/menu.json
+++ b/adventquest_function/data/att2/dialog/consciousness/guide/menu.json
@@ -38,20 +38,6 @@
                 "type": "run_command",
                 "command": "/trigger ScoreTrigger set 2859"
             }
-        },
-        {
-            "width": 150,
-            "label": {
-                "translate": "consciousness.menu.equipment_swap",
-                "color": "#21BCFF"
-            },
-            "tooltip": {
-                "translate": "consciousness.menu.equipment_swap.tip"
-            },
-            "action": {
-                "type": "run_command",
-                "command": "/trigger ScoreTrigger set 2859"
-            }
         }
     ],
     "exit_action": {

--- a/adventquest_function/data/att2/dialog/gametip/attribute.json
+++ b/adventquest_function/data/att2/dialog/gametip/attribute.json
@@ -1,196 +1,210 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.attribute",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.attribute",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.attribute.12",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.attribute.53",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.attribute.54",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.55",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.56",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.57",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.58",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.59",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.60",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.61",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.62",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.63",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "12.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.64",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "13.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.attribute.65",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/boss.json
+++ b/adventquest_function/data/att2/dialog/gametip/boss.json
@@ -1,70 +1,70 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.boss",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.boss",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.boss.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.boss.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.boss.3",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.boss.167",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.boss.168",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.boss.169",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/conscience.json
+++ b/adventquest_function/data/att2/dialog/gametip/conscience.json
@@ -1,322 +1,238 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.conscience",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.conscience",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.12",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n13.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.13",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n14.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.14",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n15.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.15",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n16.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.16",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n17.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.17",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n18.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.18",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n19.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.19",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n20.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.20",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 300,
-            "contents": [
-                {
-                    "text": "\n21.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.conscience.21",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.conscience.1",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.conscience.2",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.3",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.4",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.5",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.6",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.7",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.8",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.9",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.10",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.11",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "12.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.12",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "13.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.13",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "14.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.14",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "15.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.conscience.15",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/dahal.json
+++ b/adventquest_function/data/att2/dialog/gametip/dahal.json
@@ -1,546 +1,616 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.dahal",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.dahal",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.12",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "13.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.13",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "14.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.14",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "15.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.15",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "16.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.16",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "17.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.17",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "18.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.18",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "19.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.19",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "20.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.20",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "21.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.21",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "22.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.22",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "23.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.23",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "24.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.24",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "25.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.25",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "26.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.26",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "27.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.27",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "28.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.28",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "29.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.29",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "30.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.30",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "31.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.31",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "32.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.32",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "33.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.33",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "34.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.34",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "35.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.35",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "36.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.36",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "37.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.dahal.37",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.dahal.118",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.dahal.119",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.120",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.121",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.122",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.123",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.124",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.125",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.126",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.127",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.128",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "12.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.129",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "13.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.130",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "14.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.131",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "15.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.132",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "16.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.133",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "17.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.134",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "18.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.135",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "19.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.136",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "20.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.137",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "21.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.138",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "22.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.139",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "23.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.140",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "24.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.141",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "25.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.142",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "26.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.143",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "27.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.144",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "28.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.145",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "29.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.146",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "30.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.147",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "31.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.148",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "32.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.149",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "33.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.150",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "34.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.151",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "35.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.152",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "36.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.153",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "37.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.154",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "38.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.155",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "39.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.156",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "40.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.157",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "41.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.158",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "42.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.dahal.159",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/difficult.json
+++ b/adventquest_function/data/att2/dialog/gametip/difficult.json
@@ -1,126 +1,126 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.difficult",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.difficult",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.difficult.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.difficult.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.difficult.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.difficult.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.difficult.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.difficult.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.difficult.7",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.difficult.29",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.difficult.30",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.difficult.31",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.difficult.32",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.difficult.33",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.difficult.34",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.difficult.35",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/enchantment.json
+++ b/adventquest_function/data/att2/dialog/gametip/enchantment.json
@@ -1,489 +1,518 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.enchantment",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.enchantment",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.12",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "13.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.13",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "14.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.14",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "15.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.15",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "16.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.16",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "17.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.17",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "18.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.18",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "19.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.19",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "20.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.20",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "21.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.21",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "22.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.22",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "23.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.23",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "24.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.24",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "25.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.25"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "26.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.26",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "27.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.27",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "28.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.28",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "29.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.29",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "30.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.30",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "31.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.31",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "32.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.32",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "33.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.enchantment.33",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.enchantment.189",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.enchantment.190",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.191",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.192",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.193",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.194",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.195",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.196",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.197",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.198",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.199",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "12.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.200",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "13.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.201",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "14.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.202",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "15.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.203",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "16.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.204",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "17.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.205",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "18.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.206",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "19.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.207",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "20.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.208",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "21.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.209",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "22.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.210",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "23.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.211",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "24.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.212",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "25.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.213",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "26.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.214",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "27.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.215",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "28.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.216",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "29.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.217",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "30.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.218",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "31.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.219",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "32.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.220",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "33.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.221",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "34.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.222",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "35.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.enchantment.223",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/exploit.json
+++ b/adventquest_function/data/att2/dialog/gametip/exploit.json
@@ -1,210 +1,238 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.exploit",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.exploit",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.12",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "13.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.exploit.13",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.exploit.75",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.exploit.76",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.77",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.78",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.79",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.80",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.81",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.82",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.83",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.84",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.85",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "12.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.86",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "13.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.87",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "14.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.88",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "15.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.exploit.89",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/gameplay.json
+++ b/adventquest_function/data/att2/dialog/gametip/gameplay.json
@@ -1,196 +1,196 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.gameplay",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.gameplay",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.gameplay.12",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.gameplay.106",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.gameplay.107",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.108",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.109",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.110",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.111",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.112",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.113",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.114",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.115",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.116",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "12.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.gameplay.117",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/item.json
+++ b/adventquest_function/data/att2/dialog/gametip/item.json
@@ -1,224 +1,266 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.item",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.item",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.12",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "13.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.13",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "14.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.item.14",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.item.36",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.item.37",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.38",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.39",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.40",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.41",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.42",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.43",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.44",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.45",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.46",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "12.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.47",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "13.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.48",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "14.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.49",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "15.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.50",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "16.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.51",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "17.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.item.52",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/legendary.json
+++ b/adventquest_function/data/att2/dialog/gametip/legendary.json
@@ -1,294 +1,294 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.legendary",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.legendary",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.12",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "13.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.13",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "14.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.14",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "15.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.15",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "16.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.16",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "17.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.17",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "18.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.18",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "19.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.legendary.19",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.legendary.170",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.legendary.171",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.172",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.173",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.174",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.175",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.176",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.177",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.178",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.179",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.180",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "12.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.181",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "13.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.182",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "14.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.183",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "15.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.184",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "16.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.185",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "17.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.186",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "18.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.187",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "19.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.legendary.188",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/leveling.json
+++ b/adventquest_function/data/att2/dialog/gametip/leveling.json
@@ -1,112 +1,126 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.leveling",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.leveling",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.leveling.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.leveling.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.leveling.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.leveling.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.leveling.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.leveling.6",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.leveling.160",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.leveling.161",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.leveling.162",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.leveling.163",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.leveling.164",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.leveling.165",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.leveling.166",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/quest.json
+++ b/adventquest_function/data/att2/dialog/gametip/quest.json
@@ -1,84 +1,84 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.quest",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.quest",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.quest.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.quest.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.quest.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.quest.4",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.quest.71",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.quest.72",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.quest.73",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.quest.74",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/random_event.json
+++ b/adventquest_function/data/att2/dialog/gametip/random_event.json
@@ -1,70 +1,84 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.random_event",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.random_event",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.random_event.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.random_event.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.random_event.3",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.random_event.90",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.random_event.91",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.random_event.92",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.random_event.93",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/reputation.json
+++ b/adventquest_function/data/att2/dialog/gametip/reputation.json
@@ -1,98 +1,98 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.reputation",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.reputation",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.reputation.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.reputation.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.reputation.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.reputation.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.reputation.5",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.reputation.66",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.reputation.67",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.reputation.68",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.reputation.69",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.reputation.70",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/runes.json
+++ b/adventquest_function/data/att2/dialog/gametip/runes.json
@@ -1,196 +1,196 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.runes",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.runes",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.runes.12",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.runes.94",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.runes.95",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.96",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.97",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.98",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.99",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.100",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.101",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.102",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.103",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.104",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "12.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.runes.105",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/shop.json
+++ b/adventquest_function/data/att2/dialog/gametip/shop.json
@@ -1,196 +1,182 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.shop",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.shop",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.2",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "3.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.3",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "4.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.4",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "5.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.5",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "6.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.6",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "7.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.7",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "8.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.8",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "9.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.9",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "10.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.10",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "11.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.11",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "12.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.shop.12",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.shop.16",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.shop.17",
+          "color": "#FA8C16"
         }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "3.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.shop.18",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "4.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.shop.19",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "5.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.shop.20",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "6.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.shop.21",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "7.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.shop.22",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "8.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.shop.23",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "9.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.shop.24",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "10.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.shop.25",
+          "color": "#FA8C16"
+        }
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "11.",
+          "color": "#FA8C16"
+        },
+        {
+          "translate": "att2.assist.shop.26",
+          "color": "#FA8C16"
+        }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/dialog/gametip/travel.json
+++ b/adventquest_function/data/att2/dialog/gametip/travel.json
@@ -1,56 +1,56 @@
 {
-    "title": "",
-    "type": "minecraft:notice",
-    "pause": false,
-    "columns": 1,
-    "body": [
+  "title": "",
+  "type": "minecraft:notice",
+  "pause": false,
+  "columns": 1,
+  "body": [
+    {
+      "type": "plain_message",
+      "contents": {
+        "translate": "consciousness.gametip.travel",
+        "color": "green"
+      }
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
         {
-            "type": "plain_message",
-            "contents": {
-                "translate": "consciousness.gametip.travel",
-                "color": "green"
-            }
+          "text": "1.",
+          "color": "#FA8C16"
         },
         {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "1.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.travel.1",
-                    "color": "#FA8C16"
-                }
-            ]
-        },
-        {
-            "type": "plain_message",
-            "width": 400,
-            "contents": [
-                {
-                    "text": "2.",
-                    "color": "#FA8C16"
-                },
-                {
-                    "translate": "att2.assist.travel.2",
-                    "color": "#FA8C16"
-                }
-            ]
+          "translate": "att2.assist.travel.27",
+          "color": "#FA8C16"
         }
-    ],
-    "action": {
-        "label": {
-            "translate": "consciousness.menu.exit",
-            "color": "#45556C"
+      ]
+    },
+    {
+      "type": "plain_message",
+      "width": 400,
+      "contents": [
+        {
+          "text": "2.",
+          "color": "#FA8C16"
         },
-        "tooltip": {
-            "translate": "consciousness.menu.exit.tip"
-        },
-        "action": {
-            "type": "run_command",
-            "command": "/trigger ScoreTrigger set 2327"
+        {
+          "translate": "att2.assist.travel.28",
+          "color": "#FA8C16"
         }
+      ]
     }
+  ],
+  "action": {
+    "label": {
+      "translate": "consciousness.menu.exit",
+      "color": "#45556C"
+    },
+    "tooltip": {
+      "translate": "consciousness.menu.exit.tip"
+    },
+    "action": {
+      "type": "run_command",
+      "command": "/trigger ScoreTrigger set 2327"
+    }
+  }
 }

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/1/init_bossbar1.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/1/init_bossbar1.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena1 Wave1							#
 #################################################################
 
-bossbar add minecraft:pool0_a1 {text:"Barbarians",color:"dark_red"}
-bossbar set minecraft:pool0_a1 name [{text:"Barbarians",color:"red"}]
+bossbar add minecraft:pool0_a1
+bossbar set minecraft:pool0_a1 name [{translate:att2.arena.name.pool0_a1_w1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/1/init_bossbar2.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/1/init_bossbar2.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena1 Wave2							#
 #################################################################
 
-bossbar add minecraft:pool0_a1 {text:"Skeletons",color:"dark_red"}
-bossbar set minecraft:pool0_a1 name [{text:"Skeletons",color:"red"}]
+bossbar add minecraft:pool0_a1
+bossbar set minecraft:pool0_a1 name [{translate:att2.arena.name.pool0_a1_w2,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/1/init_bossbar3.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/1/init_bossbar3.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena1 Wave3							#
 #################################################################
 
-bossbar add minecraft:pool0_a1 {text:"Sentinels",color:"dark_red"}
-bossbar set minecraft:pool0_a1 name [{text:"Sentinels",color:"red"}]
+bossbar add minecraft:pool0_a1
+bossbar set minecraft:pool0_a1 name [{translate:att2.arena.name.pool0_a1_w3,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/1/init_bossbar4.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/1/init_bossbar4.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena1 Wave4							#
 #################################################################
 
-bossbar add minecraft:pool0_a1 {text:"Golems",color:"dark_red"}
-bossbar set minecraft:pool0_a1 name [{text:"Golems",color:"red"}]
+bossbar add minecraft:pool0_a1
+bossbar set minecraft:pool0_a1 name [{translate:att2.arena.name.pool0_a1_w4,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/2/init_bossbar1.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/2/init_bossbar1.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena2 Wave1							#
 #################################################################
 
-bossbar add minecraft:pool0_a2 {text:"Archers",color:"dark_red"}
-bossbar set minecraft:pool0_a2 name [{text:"Archers",color:"red"}]
+bossbar add minecraft:pool0_a2
+bossbar set minecraft:pool0_a2 name [{translate:att2.arena.name.pool0_a2_w1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/2/init_bossbar2.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/2/init_bossbar2.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena2 Wave2							#
 #################################################################
 
-bossbar add minecraft:pool0_a2 {text:"Undeads",color:"dark_red"}
-bossbar set minecraft:pool0_a2 name [{text:"Undeads",color:"red"}]
+bossbar add minecraft:pool0_a2
+bossbar set minecraft:pool0_a2 name [{translate:att2.arena.name.pool0_a2_w2,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/2/init_bossbar3.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/2/init_bossbar3.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena2 Wave3							#
 #################################################################
 
-bossbar add minecraft:pool0_a2 {text:"Putrids",color:"dark_red"}
-bossbar set minecraft:pool0_a2 name [{text:"Putrids",color:"red"}]
+bossbar add minecraft:pool0_a2
+bossbar set minecraft:pool0_a2 name [{translate:att2.arena.name.pool0_a2_w3,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/2/init_bossbar4.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/2/init_bossbar4.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena2 Wave4							#
 #################################################################
 
-bossbar add minecraft:pool0_a2 {text:"Strays",color:"dark_red"}
-bossbar set minecraft:pool0_a2 name [{text:"Strays",color:"red"}]
+bossbar add minecraft:pool0_a2
+bossbar set minecraft:pool0_a2 name [{translate:att2.arena.name.pool0_a2_w4,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/3/init_bossbar1.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/3/init_bossbar1.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena3 Wave1							#
 #################################################################
 
-bossbar add minecraft:pool0_a3 {text:"Slimes",color:"dark_red"}
-bossbar set minecraft:pool0_a3 name [{text:"Slimes",color:"red"}]
+bossbar add minecraft:pool0_a3
+bossbar set minecraft:pool0_a3 name [{translate:att2.arena.name.pool0_a3_w1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/3/init_bossbar2.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/3/init_bossbar2.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena3 Wave2							#
 #################################################################
 
-bossbar add minecraft:pool0_a3 {text:"Pillagers",color:"dark_red"}
-bossbar set minecraft:pool0_a3 name [{text:"Pillagers",color:"red"}]
+bossbar add minecraft:pool0_a3
+bossbar set minecraft:pool0_a3 name [{translate:att2.arena.name.pool0_a3_w2,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/3/init_bossbar3.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/3/init_bossbar3.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena3 Wave3							#
 #################################################################
 
-bossbar add minecraft:pool0_a3 {text:"Hoglins",color:"dark_red"}
-bossbar set minecraft:pool0_a3 name [{text:"Hoglins",color:"red"}]
+bossbar add minecraft:pool0_a3
+bossbar set minecraft:pool0_a3 name [{translate:att2.arena.name.pool0_a3_w3,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/3/init_bossbar4.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/3/init_bossbar4.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena3 Wave4							#
 #################################################################
 
-bossbar add minecraft:pool0_a3 {text:"Vindicators",color:"dark_red"}
-bossbar set minecraft:pool0_a3 name [{text:"Vindicators",color:"red"}]
+bossbar add minecraft:pool0_a3
+bossbar set minecraft:pool0_a3 name [{translate:att2.arena.name.pool0_a3_w4,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/4/init_bossbar1.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/4/init_bossbar1.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena4 Wave1							#
 #################################################################
 
-bossbar add minecraft:pool0_a4 {text:"Silverfish",color:"dark_red"}
-bossbar set minecraft:pool0_a4 name [{text:"Silverfish",color:"red"}]
+bossbar add minecraft:pool0_a4
+bossbar set minecraft:pool0_a4 name [{translate:att2.arena.name.pool0_a4_w1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/4/init_bossbar2.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/4/init_bossbar2.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena4 Wave2							#
 #################################################################
 
-bossbar add minecraft:pool0_a4 {text:"Spectrums",color:"dark_red"}
-bossbar set minecraft:pool0_a4 name [{text:"Spectrums",color:"red"}]
+bossbar add minecraft:pool0_a4
+bossbar set minecraft:pool0_a4 name [{translate:att2.arena.name.pool0_a4_w2,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/4/init_bossbar3.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/4/init_bossbar3.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena4 Wave3							#
 #################################################################
 
-bossbar add minecraft:pool0_a4 {text:"Spiders",color:"dark_red"}
-bossbar set minecraft:pool0_a4 name [{text:"Spiders",color:"red"}]
+bossbar add minecraft:pool0_a4
+bossbar set minecraft:pool0_a4 name [{translate:att2.arena.name.pool0_a4_w3,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/4/init_bossbar4.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/4/init_bossbar4.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena4 Wave4							#
 #################################################################
 
-bossbar add minecraft:pool0_a4 {text:"Pirates",color:"dark_red"}
-bossbar set minecraft:pool0_a4 name [{text:"Pirates",color:"red"}]
+bossbar add minecraft:pool0_a4
+bossbar set minecraft:pool0_a4 name [{translate:att2.arena.name.pool0_a4_w4,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/5/init_bossbar1.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/5/init_bossbar1.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena5 Wave1							#
 #################################################################
 
-bossbar add minecraft:pool0_a5 {text:"Thiefs",color:"dark_red"}
-bossbar set minecraft:pool0_a5 name [{text:"Thiefs",color:"red"}]
+bossbar add minecraft:pool0_a5
+bossbar set minecraft:pool0_a5 name [{translate:att2.arena.name.pool0_a5_w1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/5/init_bossbar2.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/5/init_bossbar2.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena5 Wave2							#
 #################################################################
 
-bossbar add minecraft:pool0_a5 {text:"Magmas",color:"dark_red"}
-bossbar set minecraft:pool0_a5 name [{text:"Magmas",color:"red"}]
+bossbar add minecraft:pool0_a5
+bossbar set minecraft:pool0_a5 name [{translate:att2.arena.name.pool0_a5_w2,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/5/init_bossbar3.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/5/init_bossbar3.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena5 Wave3							#
 #################################################################
 
-bossbar add minecraft:pool0_a5 {text:"Small Zombies",color:"dark_red"}
-bossbar set minecraft:pool0_a5 name [{text:"Small Zombies",color:"red"}]
+bossbar add minecraft:pool0_a5
+bossbar set minecraft:pool0_a5 name [{translate:att2.arena.name.pool0_a5_w3,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool0/5/init_bossbar4.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool0/5/init_bossbar4.mcfunction
@@ -3,5 +3,5 @@
 #Initialize bossbar Pool0 Arena5 Wave4							#
 #################################################################
 
-bossbar add minecraft:pool0_a5 {text:"Withers",color:"dark_red"}
-bossbar set minecraft:pool0_a5 name [{text:"Withers",color:"red"}]
+bossbar add minecraft:pool0_a5
+bossbar set minecraft:pool0_a5 name [{translate:att2.arena.name.pool0_a5_w4,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool1/1/bossbar_health.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool1/1/bossbar_health.mcfunction
@@ -8,10 +8,10 @@ execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=2
 execute if score Pool1_A1 ARENA matches 0.. unless entity @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=spider,tag=Atricanth] run bossbar remove minecraft:atricanth
 execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=spider,tag=Atricanth,limit=1] store result bossbar minecraft:atricanth max run attribute @s max_health get
 # Felroth
-execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleon,tag=Felroth,limit=1] store result bossbar minecraft:felroth value run scoreboard players get @s ENEMYHEALTH
-execute if score Pool1_A1 ARENA matches 0.. unless entity @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleon,tag=Felroth,limit=1] run bossbar remove minecraft:felroth
-execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleon,tag=Felroth,limit=1] store result bossbar minecraft:felroth max run attribute @s max_health get
+execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleton,tag=Felroth,limit=1] store result bossbar minecraft:felroth value run scoreboard players get @s ENEMYHEALTH
+execute if score Pool1_A1 ARENA matches 0.. unless entity @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleton,tag=Felroth,limit=1] run bossbar remove minecraft:felroth
+execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleton,tag=Felroth,limit=1] store result bossbar minecraft:felroth max run attribute @s max_health get
 # Myrath
-execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleon,tag=Myrath,limit=1] store result bossbar minecraft:myrath value run scoreboard players get @s ENEMYHEALTH
-execute if score Pool1_A1 ARENA matches 0.. unless entity @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleon,tag=Myrath,limit=1] run bossbar remove minecraft:myrath
-execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleon,tag=Myrath,limit=1] store result bossbar minecraft:myrath max run attribute @s max_health get
+execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleton,tag=Myrath,limit=1] store result bossbar minecraft:myrath value run scoreboard players get @s ENEMYHEALTH
+execute if score Pool1_A1 ARENA matches 0.. unless entity @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleton,tag=Myrath,limit=1] run bossbar remove minecraft:myrath
+execute if score Pool1_A1 ARENA matches 0.. as @e[x=5034,y=71,z=-5027,dx=54,dy=27,dz=54,type=skeleton,tag=Myrath,limit=1] store result bossbar minecraft:myrath max run attribute @s max_health get

--- a/adventquest_function/data/att2/function/gameplay/arena/pool1/1/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool1/1/init_bossbar.mcfunction
@@ -3,20 +3,20 @@
 #Initialize bossbar health Pool1 Arena1							#
 #################################################################
 
-bossbar add minecraft:atricanth {text:"Atricanth",color:"dark_red"}
+bossbar add minecraft:atricanth
 bossbar set minecraft:atricanth style notched_12
 bossbar set minecraft:atricanth players @a
 bossbar set minecraft:atricanth color purple
-bossbar set minecraft:atricanth name [{text:"Atricanth",color:"red"}]
+bossbar set minecraft:atricanth name [{translate:att2.boss.name.atricanth,color:"red"}]
 
-bossbar add minecraft:felroth {text:"Felroth",color:"dark_red"}
+bossbar add minecraft:felroth
 bossbar set minecraft:felroth style notched_12
 bossbar set minecraft:felroth players @a
 bossbar set minecraft:felroth color purple
-bossbar set minecraft:felroth name [{text:"Felroth",color:"red"}]
+bossbar set minecraft:felroth name [{translate:att2.boss.name.felroth,color:"red"}]
 
-bossbar add minecraft:myrath {text:"Myrath",color:"dark_red"}
+bossbar add minecraft:myrath
 bossbar set minecraft:myrath style notched_12
 bossbar set minecraft:myrath players @a
 bossbar set minecraft:myrath color purple
-bossbar set minecraft:myrath name [{text:"Myrath",color:"red"}]
+bossbar set minecraft:myrath name [{translate:att2.boss.name.myrath,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool1/2/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool1/2/init_bossbar.mcfunction
@@ -3,20 +3,20 @@
 #Initialize bossbar health Pool1 Arena2							#
 #################################################################
 
-bossbar add minecraft:scavenger {text:"Scavenger",color:"dark_red"}
+bossbar add minecraft:scavenger
 bossbar set minecraft:scavenger style notched_12
 bossbar set minecraft:scavenger players @a
 bossbar set minecraft:scavenger color purple
-bossbar set minecraft:scavenger name [{text:"Scavenger",color:"red"}]
+bossbar set minecraft:scavenger name [{translate:att2.boss.name.scavenger,color:"red"}]
 
-bossbar add minecraft:rackham {text:"Rackham",color:"dark_red"}
+bossbar add minecraft:rackham
 bossbar set minecraft:rackham style notched_12
 bossbar set minecraft:rackham players @a
 bossbar set minecraft:rackham color purple
-bossbar set minecraft:rackham name [{text:"Rackham",color:"red"}]
+bossbar set minecraft:rackham name [{translate:att2.boss.name.rackham,color:"red"}]
 
-bossbar add minecraft:abmup {text:"Abmup",color:"dark_red"}
+bossbar add minecraft:abmup
 bossbar set minecraft:abmup style notched_12
 bossbar set minecraft:abmup players @a
 bossbar set minecraft:abmup color purple
-bossbar set minecraft:abmup name [{text:"Abmup",color:"red"}]
+bossbar set minecraft:abmup name [{translate:att2.boss.name.abmup,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool1/3/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool1/3/init_bossbar.mcfunction
@@ -3,20 +3,20 @@
 #Initialize bossbar health Pool1 Arena3							#
 #################################################################
 
-bossbar add minecraft:vonaheim {text:"Vonaheim",color:"dark_red"}
+bossbar add minecraft:vonaheim
 bossbar set minecraft:vonaheim style notched_12
 bossbar set minecraft:vonaheim players @a
 bossbar set minecraft:vonaheim color purple
-bossbar set minecraft:vonaheim name [{text:"Vonaheim",color:"red"}]
+bossbar set minecraft:vonaheim name [{translate:att2.boss.name.vonaheim,color:"red"}]
 
-bossbar add minecraft:miehanov {text:"Miehanov",color:"dark_red"}
+bossbar add minecraft:miehanov
 bossbar set minecraft:miehanov style notched_12
 bossbar set minecraft:miehanov players @a
 bossbar set minecraft:miehanov color purple
-bossbar set minecraft:miehanov name [{text:"Miehanov",color:"red"}]
+bossbar set minecraft:miehanov name [{translate:att2.boss.name.miehanov,color:"red"}]
 
-bossbar add minecraft:ted {text:"Ted",color:"dark_red"}
+bossbar add minecraft:ted
 bossbar set minecraft:ted style notched_12
 bossbar set minecraft:ted players @a
 bossbar set minecraft:ted color purple
-bossbar set minecraft:ted name [{text:"Ted",color:"red"}]
+bossbar set minecraft:ted name [{translate:att2.boss.name.ted,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool1/4/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool1/4/init_bossbar.mcfunction
@@ -3,20 +3,20 @@
 #Initialize bossbar health Pool1 Arena4							#
 #################################################################
 
-bossbar add minecraft:karon {text:"Karon",color:"dark_red"}
+bossbar add minecraft:karon
 bossbar set minecraft:karon style notched_12
 bossbar set minecraft:karon players @a
 bossbar set minecraft:karon color purple
-bossbar set minecraft:karon name [{text:"Karon",color:"red"}]
+bossbar set minecraft:karon name [{translate:att2.boss.name.karon,color:"red"}]
 
-bossbar add minecraft:rodmat {text:"Rodmat",color:"dark_red"}
+bossbar add minecraft:rodmat
 bossbar set minecraft:rodmat style notched_12
 bossbar set minecraft:rodmat players @a
 bossbar set minecraft:rodmat color purple
-bossbar set minecraft:rodmat name [{text:"Rodmat",color:"red"}]
+bossbar set minecraft:rodmat name [{translate:att2.boss.name.rodmat,color:"red"}]
 
-bossbar add minecraft:ulkoggumi {text:"Ulkoggumi",color:"dark_red"}
+bossbar add minecraft:ulkoggumi
 bossbar set minecraft:ulkoggumi style notched_12
 bossbar set minecraft:ulkoggumi players @a
 bossbar set minecraft:ulkoggumi color purple
-bossbar set minecraft:ulkoggumi name [{text:"Ulkoggumi",color:"red"}]
+bossbar set minecraft:ulkoggumi name [{translate:att2.boss.name.ulkoggumi,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool1/5/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool1/5/init_bossbar.mcfunction
@@ -3,20 +3,20 @@
 #Initialize bossbar health Pool1 Arena5							#
 #################################################################
 
-bossbar add minecraft:illusion {text:"Illusion",color:"dark_red"}
+bossbar add minecraft:illusion
 bossbar set minecraft:illusion style notched_12
 bossbar set minecraft:illusion players @a
 bossbar set minecraft:illusion color purple
-bossbar set minecraft:illusion name [{text:"Illusion",color:"red"}]
+bossbar set minecraft:illusion name [{translate:att2.boss.name.illusion,color:"red"}]
 
-bossbar add minecraft:naer {text:"Naer",color:"dark_red"}
+bossbar add minecraft:naer
 bossbar set minecraft:naer style notched_12
 bossbar set minecraft:naer players @a
 bossbar set minecraft:naer color purple
-bossbar set minecraft:naer name [{text:"Naer",color:"red"}]
+bossbar set minecraft:naer name [{translate:att2.boss.name.naer,color:"red"}]
 
-bossbar add minecraft:aozathreyon {text:"Aozathreyon",color:"dark_red"}
+bossbar add minecraft:aozathreyon
 bossbar set minecraft:aozathreyon style notched_12
 bossbar set minecraft:aozathreyon players @a
 bossbar set minecraft:aozathreyon color purple
-bossbar set minecraft:aozathreyon name [{text:"Aozathreyon",color:"red"}]
+bossbar set minecraft:aozathreyon name [{translate:att2.boss.name.aozathreyon,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool1/6/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool1/6/init_bossbar.mcfunction
@@ -3,20 +3,20 @@
 #Initialize bossbar health Pool1 Arena6							#
 #################################################################
 
-bossbar add minecraft:shadow {text:"Shadow",color:"dark_red"}
+bossbar add minecraft:shadow
 bossbar set minecraft:shadow style notched_12
 bossbar set minecraft:shadow players @a
 bossbar set minecraft:shadow color purple
-bossbar set minecraft:shadow name [{text:"Shadow",color:"red"}]
+bossbar set minecraft:shadow name [{translate:att2.boss.name.shadow,color:"red"}]
 
-bossbar add minecraft:subject {text:"Subject",color:"dark_red"}
+bossbar add minecraft:subject
 bossbar set minecraft:subject style notched_12
 bossbar set minecraft:subject players @a
 bossbar set minecraft:subject color purple
-bossbar set minecraft:subject name [{text:"Subject",color:"red"}]
+bossbar set minecraft:subject name [{translate:att2.boss.name.subject,color:"red"}]
 
-bossbar add minecraft:korlaph {text:"Korlaph",color:"dark_red"}
+bossbar add minecraft:korlaph
 bossbar set minecraft:korlaph style notched_12
 bossbar set minecraft:korlaph players @a
 bossbar set minecraft:korlaph color purple
-bossbar set minecraft:korlaph name [{text:"Korlaph",color:"red"}]
+bossbar set minecraft:korlaph name [{translate:att2.boss.name.korlaph,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool1/7/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool1/7/init_bossbar.mcfunction
@@ -3,20 +3,20 @@
 #Initialize bossbar health Pool1 Arena7							#
 #################################################################
 
-bossbar add minecraft:asurok {text:"Asurok",color:"dark_red"}
+bossbar add minecraft:asurok
 bossbar set minecraft:asurok style notched_12
 bossbar set minecraft:asurok players @a
 bossbar set minecraft:asurok color purple
-bossbar set minecraft:asurok name [{text:"Asurok",color:"red"}]
+bossbar set minecraft:asurok name [{translate:att2.boss.name.asurok,color:"red"}]
 
-bossbar add minecraft:torkant {text:"Torkant",color:"dark_red"}
+bossbar add minecraft:torkant
 bossbar set minecraft:torkant style notched_12
 bossbar set minecraft:torkant players @a
 bossbar set minecraft:torkant color purple
-bossbar set minecraft:torkant name [{text:"Torkant",color:"red"}]
+bossbar set minecraft:torkant name [{translate:att2.boss.name.torkant,color:"red"}]
 
-bossbar add minecraft:blobby {text:"Blobby",color:"dark_red"}
+bossbar add minecraft:blobby
 bossbar set minecraft:blobby style notched_12
 bossbar set minecraft:blobby players @a
 bossbar set minecraft:blobby color purple
-bossbar set minecraft:blobby name [{text:"Blobby",color:"red"}]
+bossbar set minecraft:blobby name [{translate:att2.boss.name.blobby,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/arena/pool2/1/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool2/1/init_bossbar.mcfunction
@@ -3,9 +3,9 @@
 #Initialize bossbar health Pool2 Arena1							#
 #################################################################
 
-bossbar add minecraft:pool2_a1 {text:"League of Time",color:"dark_red"}
+bossbar add minecraft:pool2_a1
 bossbar set minecraft:pool2_a1 style notched_12
 bossbar set minecraft:pool2_a1 players @a
 bossbar set minecraft:pool2_a1 color purple
-bossbar set minecraft:pool2_a1 name [{text:"League of Time",color:"red"}]
+bossbar set minecraft:pool2_a1 name [{translate:att2.arena.name.pool2_a1,color:"red"}]
 bossbar set minecraft:pool2_a1 max 6

--- a/adventquest_function/data/att2/function/gameplay/arena/pool2/2/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool2/2/init_bossbar.mcfunction
@@ -3,9 +3,9 @@
 #Initialize bossbar health Pool2 Arena2							#
 #################################################################
 
-bossbar add minecraft:pool2_a2 {text:"League of Space",color:"dark_red"}
+bossbar add minecraft:pool2_a2
 bossbar set minecraft:pool2_a2 style notched_12
 bossbar set minecraft:pool2_a2 players @a
 bossbar set minecraft:pool2_a2 color purple
-bossbar set minecraft:pool2_a2 name [{text:"League of Space",color:"red"}]
+bossbar set minecraft:pool2_a2 name [{translate:att2.arena.name.pool2_a2,color:"red"}]
 bossbar set minecraft:pool2_a2 max 6

--- a/adventquest_function/data/att2/function/gameplay/arena/pool2/3/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool2/3/init_bossbar.mcfunction
@@ -3,9 +3,9 @@
 #Initialize bossbar health Pool2 Arena3							#
 #################################################################
 
-bossbar add minecraft:pool2_a3 {text:"League of Ether",color:"dark_red"}
+bossbar add minecraft:pool2_a3
 bossbar set minecraft:pool2_a3 style notched_12
 bossbar set minecraft:pool2_a3 players @a
 bossbar set minecraft:pool2_a3 color purple
-bossbar set minecraft:pool2_a3 name [{text:"League of Ether",color:"red"}]
+bossbar set minecraft:pool2_a3 name [{translate:att2.arena.name.pool2_a3,color:"red"}]
 bossbar set minecraft:pool2_a3 max 6

--- a/adventquest_function/data/att2/function/gameplay/arena/pool3/1/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool3/1/init_bossbar.mcfunction
@@ -3,9 +3,9 @@
 #Initialize bossbar health Pool3 Arena1							#
 #################################################################
 
-bossbar add minecraft:pool3_a1 {text:"League of Dimensions",color:"dark_red"}
+bossbar add minecraft:pool3_a1
 bossbar set minecraft:pool3_a1 style notched_12
 bossbar set minecraft:pool3_a1 players @a
 bossbar set minecraft:pool3_a1 color purple
-bossbar set minecraft:pool3_a1 name [{text:"League of Dimensions",color:"red"}]
+bossbar set minecraft:pool3_a1 name [{translate:att2.arena.name.pool3_a1,color:"red"}]
 bossbar set minecraft:pool3_a1 max 20

--- a/adventquest_function/data/att2/function/gameplay/arena/pool4/1/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/arena/pool4/1/init_bossbar.mcfunction
@@ -3,8 +3,8 @@
 #Initialize bossbar health Pool4 Arena1							#
 #################################################################
 
-bossbar add minecraft:pool4_a1 {text:"SUIRUCREM",color:"dark_red"}
+bossbar add minecraft:pool4_a1
 bossbar set minecraft:pool4_a1 style notched_12
 bossbar set minecraft:pool4_a1 players @a
 bossbar set minecraft:pool4_a1 color purple
-bossbar set minecraft:pool4_a1 name [{text:"SUIRUCREM",color:"red"}]
+bossbar set minecraft:pool4_a1 name [{translate:att2.arena.name.pool4_a1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/enter_arena.mcfunction
@@ -10,3 +10,6 @@ scoreboard players set @s MUSIC_BOSS 0
 
 ##show bossbar
 bossbar set minecraft:myrath players @s
+
+##show display_title
+function att2:gameplay/boss/adanoi/myrath/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/go.mcfunction
@@ -11,6 +11,8 @@
 particle minecraft:dust{color:[1,0,0],scale:1} -3892 85 -5592 1 2 0 1 5 normal
 particle minecraft:dust{color:[1,0,0],scale:1} -3892 85 -5616 1 2 0 1 5 normal
 
+##delay time
+execute if score myrath_t BOSS_TIME matches ..-1 run return run scoreboard players add myrath_t BOSS_TIME 1
 # Music management
 execute if score Myrath SQ26 matches 0.. as @a[x=-3881,y=83,z=-5592,dx=-22,dy=11,dz=-24,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Myrath SQ26 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -20,7 +22,7 @@ execute if score Myrath SQ26 matches 0.. if entity @a[x=-3881,y=83,z=-5592,dx=-2
 execute if score Myrath SQ26 matches 0.. if entity @a[x=-3881,y=83,z=-5592,dx=-22,dy=11,dz=-24,gamemode=adventure] store result bossbar minecraft:myrath max run attribute 00000000-0000-001c-0000-00000000001c max_health get
 
 # Make challengers enters the arena
-execute if score SQ26 SIDEQUEST matches 5 as @a[x=-3890,y=85,z=-5591,dx=-4,dy=3,dz=0,gamemode=adventure] at @s unless entity @a[x=-3881,y=83,z=-5592,dx=-22,dy=11,dz=-24,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/adanoi/myrath/display_title
+#execute if score SQ26 SIDEQUEST matches 5 as @a[x=-3890,y=85,z=-5591,dx=-4,dy=3,dz=0,gamemode=adventure] at @s unless entity @a[x=-3881,y=83,z=-5592,dx=-22,dy=11,dz=-24,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/adanoi/myrath/display_title
 execute if score EnterArena SQ26 matches ..0 as @a[x=-3890,y=85,z=-5591,dx=-4,dy=3,dz=0,gamemode=adventure] run function att2:gameplay/boss/adanoi/myrath/enter_arena
 execute if score EnterArena SQ26 matches 1.. run scoreboard players remove EnterArena SQ26 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:myrath {"selector":"00000000-0000-001c-0000-00000000001c",
 bossbar set minecraft:myrath style notched_12
 bossbar set minecraft:myrath players @a[x=-3881,y=83,z=-5592,dx=-22,dy=11,dz=-24,gamemode=adventure]
 bossbar set minecraft:myrath color purple
-bossbar set minecraft:myrath name [{text:"Myrath",color:"red"}]
+bossbar set minecraft:myrath name [{translate:att2.boss.name.myrath,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset myrath_t BOSS_TIME
+scoreboard players set myrath_t BOSS_TIME -40
 scoreboard players reset myrath_s BOSS_TIME
 scoreboard players reset myrath_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/adanoi/myrath/time/time_over.mcfunction
@@ -25,6 +25,6 @@ execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME mat
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/adanoi/myrath/time/time_show
 
 ##reset
-scoreboard players reset myrath_t BOSS_TIME
+scoreboard players set myrath_t BOSS_TIME -40
 scoreboard players reset myrath_s BOSS_TIME
 scoreboard players reset myrath_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/enter_arena.mcfunction
@@ -9,3 +9,6 @@ tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 
 bossbar set minecraft:atricanth3 players @s
+
+##show display_title
+function att2:gameplay/boss/angband/atricanth/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/go.mcfunction
@@ -14,6 +14,9 @@ execute if score Atricanth SQ57 matches 0.. run function att2:gameplay/boss/angb
 particle minecraft:dust{color:[1,0,0],scale:1} 3425 33.5 4303 1.5 0.1 1.5 0 5 force
 particle minecraft:dust{color:[1,0,0],scale:1} 3446 20.5 4303 0.1 1.2 1.2 0 5 force
 
+##delay time
+execute if score atricanth_t BOSS_TIME matches ..-1 run return run scoreboard players add atricanth_t BOSS_TIME 1
+
 # Music management
 execute if score Atricanth SQ57 matches 0.. in minecraft:the_nether as @a[x=3445,y=32,z=4323,dx=-40,dy=-18,dz=-40,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Atricanth SQ57 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -33,7 +36,7 @@ execute if score Atricanth SQ57 matches 0.. unless entity 00000000-0000-029c-000
 execute if score Atricanth SQ57 matches 0.. in minecraft:the_nether if entity @a[x=3445,y=32,z=4323,dx=-40,dy=-18,dz=-40,gamemode=adventure] store result bossbar minecraft:atricanth3 max run data get entity 00000000-0000-029c-0000-00000000029c attributes[{id:"minecraft:max_health"}].base
 
 # Make challengers enters the arena
-execute if score SQ57 SIDEQUEST matches 1..99 in minecraft:the_nether as @a[x=3422,y=34,z=4306,dx=6,dy=2,dz=-6,gamemode=adventure] at @s unless entity @a[x=3445,y=32,z=4323,dx=-40,dy=-18,dz=-40,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/angband/atricanth/display_title
+#execute if score SQ57 SIDEQUEST matches 1..99 in minecraft:the_nether as @a[x=3422,y=34,z=4306,dx=6,dy=2,dz=-6,gamemode=adventure] at @s unless entity @a[x=3445,y=32,z=4323,dx=-40,dy=-18,dz=-40,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/angband/atricanth/display_title
 execute if score EnterArena SQ57 matches ..0 in minecraft:the_nether as @a[x=3422,y=34,z=4306,dx=6,dy=2,dz=-6,gamemode=adventure] run function att2:gameplay/boss/angband/atricanth/enter_arena
 execute if score EnterArena SQ57 matches 1.. run scoreboard players remove EnterArena SQ57 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/init_bossbar.mcfunction
@@ -7,16 +7,16 @@ bossbar add minecraft:atricanth1 {"selector":"00000000-0000-027c-0000-0000000002
 bossbar set minecraft:atricanth1 style notched_12
 bossbar set minecraft:atricanth1 players @a[x=3445,y=32,z=4323,dx=-40,dy=-18,dz=-40,gamemode=adventure]
 bossbar set minecraft:atricanth1 color purple
-bossbar set minecraft:atricanth1 name [{text:"Atricanth",color:"red"}]
+bossbar set minecraft:atricanth1 name [{translate:att2.boss.name.atricanth,color:"red"}]
 
 bossbar add minecraft:atricanth2 {"selector":"00000000-0000-028c-0000-00000000028c",color:"dark_red"}
 bossbar set minecraft:atricanth2 style notched_12
 bossbar set minecraft:atricanth2 players @a[x=3445,y=32,z=4323,dx=-40,dy=-18,dz=-40,gamemode=adventure]
 bossbar set minecraft:atricanth2 color purple
-bossbar set minecraft:atricanth2 name [{text:"Atricanth",color:"red"}]
+bossbar set minecraft:atricanth2 name [{translate:att2.boss.name.atricanth,color:"red"}]
 
 bossbar add minecraft:atricanth3 {"selector":"00000000-0000-029c-0000-00000000029c",color:"dark_red"}
 bossbar set minecraft:atricanth3 style notched_12
 bossbar set minecraft:atricanth3 players @a[x=3445,y=32,z=4323,dx=-40,dy=-18,dz=-40,gamemode=adventure]
 bossbar set minecraft:atricanth3 color purple
-bossbar set minecraft:atricanth3 name [{text:"Atricanth",color:"red"}]
+bossbar set minecraft:atricanth3 name [{translate:att2.boss.name.atricanth,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset atricanth_t BOSS_TIME
+scoreboard players set atricanth_t BOSS_TIME -40
 scoreboard players reset atricanth_s BOSS_TIME
 scoreboard players reset atricanth_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/atricanth/time/time_over.mcfunction
@@ -23,6 +23,6 @@ scoreboard players operation test_t BOSS_TIME -= atricanth_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/angband/atricanth/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/angband/atricanth/time/time_show
 
-scoreboard players reset atricanth_t BOSS_TIME
+scoreboard players set atricanth_t BOSS_TIME -40
 scoreboard players reset atricanth_s BOSS_TIME
 scoreboard players reset atricanth_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/flamme_noire/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/flamme_noire/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:flamme_noire {"selector":"@e[type=minecraft:ghast,nbt={UUI
 bossbar set minecraft:flamme_noire style notched_12
 bossbar set minecraft:flamme_noire players @a[x=3514,y=56,z=4924,distance=..100]
 bossbar set minecraft:flamme_noire color purple
-bossbar set minecraft:flamme_noire name [{text:"La Flamme Noire",color:"dark_red"}]
+bossbar set minecraft:flamme_noire name [{translate:att2.boss.name.flamme_noire,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/karon/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/karon/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:karon players @s
+
+##show display_title
+function att2:gameplay/boss/angband/karon/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/karon/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/karon/go.mcfunction
@@ -14,6 +14,9 @@ execute if score Karon ANGOR matches 0.. run function att2:gameplay/boss/angband
 particle minecraft:dust{color:[1,0,0],scale:1} 3510 124 4515 0.1 1.2 1.2 0 5 force
 particle minecraft:dust{color:[1,0,0],scale:1} 3539 124 4515 0.1 1.2 1.2 0 5 force
 
+##delay time
+execute if score karon_t BOSS_TIME matches ..-1 run return run scoreboard players add karon_t BOSS_TIME 1
+
 # Music management
 execute if score Karon ANGOR matches 0.. in minecraft:the_nether as @a[x=3539,y=123,z=4497,dx=-29,dy=20,dz=50,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_demiboss
 execute if score Karon ANGOR matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -23,7 +26,7 @@ execute if score Karon ANGOR matches 0.. in minecraft:the_nether if entity @a[x=
 execute if score Karon ANGOR matches 0.. in minecraft:the_nether if entity @a[x=3539,y=123,z=4497,dx=-29,dy=20,dz=50,gamemode=adventure] store result bossbar minecraft:karon max run attribute 00000000-0000-005b-0000-00000000005b max_health get
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 71 in minecraft:the_nether as @a[x=3509,y=123,z=4513,dx=0,dy=20,dz=4,gamemode=adventure] at @s unless entity @a[x=3539,y=123,z=4497,dx=-29,dy=20,dz=50,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/angband/karon/display_title
+#execute if score Mainquest SIDEQUEST matches 71 in minecraft:the_nether as @a[x=3509,y=123,z=4513,dx=0,dy=20,dz=4,gamemode=adventure] at @s unless entity @a[x=3539,y=123,z=4497,dx=-29,dy=20,dz=50,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/angband/karon/display_title
 execute if score EnterArena ANGOR matches ..0 in minecraft:the_nether as @a[x=3509,y=123,z=4513,dx=0,dy=20,dz=4,gamemode=adventure] run function att2:gameplay/boss/angband/karon/enter_arena
 execute if score EnterArena ANGOR matches 1.. run scoreboard players remove EnterArena ANGOR 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/karon/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/karon/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:karon {"selector":"00000000-0000-005b-0000-00000000005b",c
 bossbar set minecraft:karon style notched_12
 bossbar set minecraft:karon players @a[x=3539,y=123,z=4497,dx=-29,dy=20,dz=50,gamemode=adventure]
 bossbar set minecraft:karon color purple
-bossbar set minecraft:karon name [{text:"Karön",color:"red"}]
+bossbar set minecraft:karon name [{translate:att2.boss.name.karon,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/karon/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/karon/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset karon_t BOSS_TIME
+scoreboard players set karon_t BOSS_TIME -40
 scoreboard players reset karon_s BOSS_TIME
 scoreboard players reset karon_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/karon/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/karon/time/time_over.mcfunction
@@ -23,6 +23,6 @@ scoreboard players operation test_t BOSS_TIME -= karon_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/angband/karon/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/angband/karon/time/time_show
 
-scoreboard players reset karon_t BOSS_TIME
+scoreboard players set karon_t BOSS_TIME -40
 scoreboard players reset karon_s BOSS_TIME
 scoreboard players reset karon_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:rodmat players @s
+
+##show display_title
+function att2:gameplay/boss/angband/rodmat/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/go.mcfunction
@@ -14,6 +14,9 @@ execute if score Rodmat SQ45 matches 0.. run function att2:gameplay/boss/angband
 particle minecraft:dust{color:[1,0,0],scale:1} 3790 90.5 4386 0.1 1 1 0 5
 particle minecraft:dust{color:[1,0,0],scale:1} 3734 90.5 4386 0.1 1 1 0 5
 
+##delay time
+execute if score rodmat_t BOSS_TIME matches ..-1 run return run scoreboard players add rodmat_t BOSS_TIME 1
+
 # Music management
 execute if score Rodmat SQ45 matches 0.. as @a[x=3734,y=87,z=4367,dx=56,dy=40,dz=38,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Rodmat SQ45 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -23,7 +26,7 @@ execute if score Rodmat SQ45 matches 0.. if entity @a[x=3734,y=87,z=4367,dx=56,d
 execute if score Rodmat SQ45 matches 0.. if entity @a[x=3734,y=87,z=4367,dx=56,dy=40,dz=38,gamemode=adventure] store result bossbar minecraft:rodmat max run attribute 00000000-0000-011c-0000-00000000011c max_health get
 
 # Make challengers enters the arena
-execute if score SQ45 SIDEQUEST matches 1..99 as @a[x=3791,y=89,z=4385,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=3734,y=87,z=4367,dx=56,dy=40,dz=38,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/angband/rodmat/display_title
+#execute if score SQ45 SIDEQUEST matches 1..99 as @a[x=3791,y=89,z=4385,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=3734,y=87,z=4367,dx=56,dy=40,dz=38,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/angband/rodmat/display_title
 execute if score EnterArena SQ45 matches ..0 as @a[x=3791,y=89,z=4385,dx=0,dy=2,dz=2,gamemode=adventure] run function att2:gameplay/boss/angband/rodmat/enter_arena
 execute if score EnterArena SQ45 matches 1.. run scoreboard players remove EnterArena SQ45 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:rodmat {"selector":"00000000-0000-011c-0000-00000000011c",
 bossbar set minecraft:rodmat style notched_12
 bossbar set minecraft:rodmat players @a[x=3734,y=87,z=4367,dx=56,dy=40,dz=38,gamemode=adventure]
 bossbar set minecraft:rodmat color white
-bossbar set minecraft:rodmat name [{text:"Rodmat",color:"red"}]
+bossbar set minecraft:rodmat name [{translate:att2.boss.name.rodmat,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset rodmat_t BOSS_TIME
+scoreboard players set rodmat_t BOSS_TIME -40
 scoreboard players reset rodmat_s BOSS_TIME
 scoreboard players reset rodmat_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/angband/rodmat/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= rodmat_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/angband/rodmat/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/angband/rodmat/time/time_show
 
-scoreboard players reset rodmat_t BOSS_TIME
+scoreboard players set rodmat_t BOSS_TIME -40
 scoreboard players reset rodmat_s BOSS_TIME
 scoreboard players reset rodmat_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:asurok players @s
+
+##show display_title
+function att2:gameplay/boss/asunark/asurok/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/go.mcfunction
@@ -12,6 +12,9 @@ execute if score winge_mech3 ASUNARK matches 4 run particle minecraft:dust{color
 particle minecraft:dust{color:[1,0,0],scale:1.5} -3297 7.5 -4922 0.8 0.8 0 0 2 force
 particle minecraft:dust{color:[1,0,0],scale:1.5} -3297 7.5 -4962 0.8 0.8 0 0 2 force
 
+##delay time
+execute if score asurok_t BOSS_TIME matches ..-1 run return run scoreboard players add asurok_t BOSS_TIME 1
+
 # Sound security
 stopsound @a block minecraft:block.bubble_column.bubble_pop
 stopsound @a player minecraft:block.bubble_column.whirlpool_inside
@@ -28,7 +31,7 @@ execute if score Asurok ASUNARK matches 0.. if entity @a[x=-3317,y=2,z=-4922,dx=
 execute if score Asurok ASUNARK matches 0.. if entity @a[x=-3317,y=2,z=-4922,dx=41,dy=22,dz=-41,gamemode=adventure] store result bossbar minecraft:asurok max run attribute 00000000-0000-003b-0000-00000000003b max_health get
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 39 as @a[x=-3319,y=12,z=-4943,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-3317,y=2,z=-4922,dx=41,dy=22,dz=-41,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/asunark/asurok/display_title
+#execute if score Mainquest SIDEQUEST matches 39 as @a[x=-3319,y=12,z=-4943,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-3317,y=2,z=-4922,dx=41,dy=22,dz=-41,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/asunark/asurok/display_title
 execute if score EnterArena ASUNARK matches ..0 if score winge_mech3 ASUNARK matches 4 as @a[x=-3319,y=12,z=-4943,dx=0,dy=2,dz=2,gamemode=adventure] run function att2:gameplay/boss/asunark/asurok/enter_arena
 execute if score EnterArena ASUNARK matches 1.. run scoreboard players remove EnterArena ASUNARK 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:asurok {"selector":"00000000-0000-003b-0000-00000000003b",
 bossbar set minecraft:asurok style notched_12
 bossbar set minecraft:asurok players @a[x=-3317,y=2,z=-4922,dx=41,dy=22,dz=-41,gamemode=adventure]
 bossbar set minecraft:asurok color purple
-bossbar set minecraft:asurok name [{text:"Asurok",color:"red"}]
+bossbar set minecraft:asurok name [{translate:att2.boss.name.asurok,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset asurok_t BOSS_TIME
+scoreboard players set asurok_t BOSS_TIME -40
 scoreboard players reset asurok_s BOSS_TIME
 scoreboard players reset asurok_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/asurok/time/time_over.mcfunction
@@ -23,6 +23,6 @@ scoreboard players operation test_t BOSS_TIME -= asurok_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/asunark/asurok/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/asunark/asurok/time/time_show
 
-scoreboard players reset asurok_t BOSS_TIME
+scoreboard players set asurok_t BOSS_TIME -40
 scoreboard players reset asurok_s BOSS_TIME
 scoreboard players reset asurok_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:rackham players @s
+
+##show display_title
+function att2:gameplay/boss/asunark/rackham/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/go.mcfunction
@@ -15,6 +15,9 @@ particle minecraft:dust{color:[1,0,0],scale:1.5} -4028 39 -4279 0 1.5 1.5 0 3
 stopsound @a * minecraft:block.fire.ambient
 stopsound @a * minecraft:block.fire.extinguish
 
+##delay time
+execute if score rackham_t BOSS_TIME matches ..-1 run return run scoreboard players add rackham_t BOSS_TIME 1
+
 # Music management
 execute if score Rackham SQ41 matches 0.. as @a[x=-4032,y=35,z=-4294,dx=29,dy=17,dz=30,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Rackham SQ41 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -24,7 +27,7 @@ execute if score Rackham SQ41 matches 0.. if entity @a[x=-4032,y=35,z=-4294,dx=2
 execute if score Rackham SQ41 matches 0.. if entity @a[x=-4032,y=35,z=-4294,dx=29,dy=17,dz=30,gamemode=adventure] store result bossbar minecraft:rackham max run attribute 00000000-0000-010c-0000-00000000010c max_health get
 
 # Make challengers enters the arena
-execute if score SQ41 SIDEQUEST matches 1..99 as @a[x=-4002,y=37,z=-4281,dx=0,dy=3,dz=4,gamemode=adventure] at @s unless entity @a[x=-4032,y=35,z=-4294,dx=29,dy=17,dz=30,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/asunark/rackham/display_title
+#execute if score SQ41 SIDEQUEST matches 1..99 as @a[x=-4002,y=37,z=-4281,dx=0,dy=3,dz=4,gamemode=adventure] at @s unless entity @a[x=-4032,y=35,z=-4294,dx=29,dy=17,dz=30,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/asunark/rackham/display_title
 execute if score EnterArena SQ41 matches ..0 as @a[x=-4002,y=37,z=-4281,dx=0,dy=3,dz=4,gamemode=adventure] run function att2:gameplay/boss/asunark/rackham/enter_arena
 execute if score EnterArena SQ41 matches 1.. run scoreboard players remove EnterArena SQ41 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:rackham {"selector":"00000000-0000-010c-0000-00000000010c"
 bossbar set minecraft:rackham style notched_12
 bossbar set minecraft:rackham players @a[x=-4032,y=35,z=-4294,dx=29,dy=17,dz=30,gamemode=adventure]
 bossbar set minecraft:rackham color purple
-bossbar set minecraft:rackham name [{text:"François",color:"red"}]
+bossbar set minecraft:rackham name [{translate:att2.boss.name.rackham,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset rackham_t BOSS_TIME
+scoreboard players set rackham_t BOSS_TIME -40
 scoreboard players reset rackham_s BOSS_TIME
 scoreboard players reset rackham_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/asunark/rackham/time/time_over.mcfunction
@@ -25,6 +25,6 @@ execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME mat
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/asunark/rackham/time/time_show
 
 
-scoreboard players reset rackham_t BOSS_TIME
+scoreboard players set rackham_t BOSS_TIME -40
 scoreboard players reset rackham_s BOSS_TIME
 scoreboard players reset rackham_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:elevator_level players @s
+
+##show display_title
+function att2:gameplay/boss/billgart/elevator/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/go.mcfunction
@@ -13,6 +13,9 @@ particle minecraft:dust{color:[1,0,0],scale:1} -1239 177 -620 1.5 2 0.1 0 5 forc
 particle minecraft:dust{color:[1,0,0],scale:1} -1244 177 -615 0.1 2 1.5 0 5 force
 particle minecraft:dust{color:[1,0,0],scale:1} -1234 177 -615 0.1 2 1.5 0 5 force
 
+##delay time
+execute if score elevator_t BOSS_TIME matches ..-1 run return run scoreboard players add elevator_t BOSS_TIME 1
+
 # Music management
 execute if score Elevator BILLGART matches 0.. in minecraft:the_end as @a[x=-1243,y=180,z=-619,dx=8,dy=-147,dz=8,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_boss
 execute if score Elevator BILLGART matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/init_bossbar.mcfunction
@@ -7,22 +7,22 @@ bossbar add minecraft:elevator_level {"selector":"@e[x=-1243,y=180,z=-619,dx=8,d
 bossbar set minecraft:elevator_level style notched_20
 bossbar set minecraft:elevator_level players @a[x=-1243,y=180,z=-619,dx=8,dy=-147,dz=8,gamemode=adventure]
 bossbar set minecraft:elevator_level color white
-bossbar set minecraft:elevator_level name [{text:"Elevator Level",color:"gray"}]
+bossbar set minecraft:elevator_level name [{translate:att2.boss.name.elevator_level,color:"red"}]
 
 bossbar add minecraft:guardian_emerald {"selector":"00000000-0000-012b-0000-00000000012b",color:"dark_red"}
 bossbar set minecraft:guardian_emerald style notched_12
 bossbar set minecraft:guardian_emerald players @a[x=-1243,y=180,z=-619,dx=8,dy=-147,dz=8,gamemode=adventure]
 bossbar set minecraft:guardian_emerald color green
-bossbar set minecraft:guardian_emerald name [{text:"Emerald Guardian",color:"dark_green"}]
+bossbar set minecraft:guardian_emerald name [{translate:att2.boss.name.guardian_emerald,color:"red"}]
 
 bossbar add minecraft:guardian_iron {"selector":"00000000-0000-013b-0000-00000000013b",color:"dark_red"}
 bossbar set minecraft:guardian_iron style notched_12
 bossbar set minecraft:guardian_iron players @a[x=-1243,y=180,z=-619,dx=8,dy=-147,dz=8,gamemode=adventure]
 bossbar set minecraft:guardian_iron color green
-bossbar set minecraft:guardian_iron name [{text:"Iron Guardian",color:"dark_green"}]
+bossbar set minecraft:guardian_iron name [{translate:att2.boss.name.guardian_iron,color:"red"}]
 
 bossbar add minecraft:guardian_silver {"selector":"00000000-0000-011b-0000-00000000011b",color:"dark_red"}
 bossbar set minecraft:guardian_silver style notched_12
 bossbar set minecraft:guardian_silver players @a[x=-1243,y=180,z=-619,dx=8,dy=-147,dz=8,gamemode=adventure]
 bossbar set minecraft:guardian_silver color green
-bossbar set minecraft:guardian_silver name [{text:"Silver Guardian",color:"dark_green"}]
+bossbar set minecraft:guardian_silver name [{translate:att2.boss.name.guardian_silver,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset elevator_t BOSS_TIME
+scoreboard players set elevator_t BOSS_TIME -40
 scoreboard players reset elevator_s BOSS_TIME
 scoreboard players reset elevator_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/elevator/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= elevator_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/billgart/elevator/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/billgart/elevator/time/time_show
 
-scoreboard players reset elevator_t BOSS_TIME
+scoreboard players set elevator_t BOSS_TIME -40
 scoreboard players reset elevator_s BOSS_TIME
 scoreboard players reset elevator_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:gestrom players @s
+
+##show display_title
+function att2:gameplay/boss/billgart/gestrom/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/go.mcfunction
@@ -11,6 +11,9 @@
 particle minecraft:dust{color:[1,0,0],scale:1} -1139 200 -679 0.1 1 1 0 5 force
 particle minecraft:dust{color:[1,0,0],scale:1} -1134.0 201 -668 0.8 1.2 0.1 0 5 force
 
+##delay time
+execute if score gestrom_t BOSS_TIME matches ..-1 run return run scoreboard players add gestrom_t BOSS_TIME 1
+
 # Music management
 execute if score Gestrom BILLGART matches 0.. in minecraft:the_end as @a[x=-1130,y=199,z=-690,dx=-9,dy=10,dz=22,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_demiboss
 execute if score Gestrom BILLGART matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -20,7 +23,7 @@ execute if score Gestrom BILLGART matches 0.. in minecraft:the_end if entity @a[
 execute if score Gestrom BILLGART matches 0.. in minecraft:the_end if entity @a[x=-1130,y=199,z=-690,dx=-9,dy=10,dz=22,gamemode=adventure] store result bossbar minecraft:gestrom max run attribute 00000000-0000-014b-0000-00000000014b max_health get
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 169 in minecraft:the_end as @a[x=-1140,y=199,z=-678,dx=0,dy=2,dz=-2,gamemode=adventure] at @s unless entity @a[x=-1130,y=199,z=-690,dx=-9,dy=10,dz=22,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/billgart/gestrom/display_title
+#execute if score Mainquest SIDEQUEST matches 169 in minecraft:the_end as @a[x=-1140,y=199,z=-678,dx=0,dy=2,dz=-2,gamemode=adventure] at @s unless entity @a[x=-1130,y=199,z=-690,dx=-9,dy=10,dz=22,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/billgart/gestrom/display_title
 execute if score EnterArena BILLGART matches ..0 in minecraft:the_end as @a[x=-1140,y=199,z=-678,dx=0,dy=2,dz=-2,gamemode=adventure] run function att2:gameplay/boss/billgart/gestrom/enter_arena
 execute if score EnterArena BILLGART matches 1.. run scoreboard players remove EnterArena BILLGART 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:gestrom {"selector":"00000000-0000-014b-0000-00000000014b"
 bossbar set minecraft:gestrom style notched_12
 bossbar set minecraft:gestrom players @a[x=-1130,y=199,z=-690,dx=-9,dy=10,dz=22,gamemode=adventure]
 bossbar set minecraft:gestrom color purple
-bossbar set minecraft:gestrom name [{text:"Geström",color:"red"}]
+bossbar set minecraft:gestrom name [{translate:att2.boss.name.gestrom,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset gestrom_t BOSS_TIME
+scoreboard players set gestrom_t BOSS_TIME -40
 scoreboard players reset gestrom_s BOSS_TIME
 scoreboard players reset gestrom_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/gestrom/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= gestrom_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/billgart/gestrom/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/billgart/gestrom/time/time_show
 
-scoreboard players reset gestrom_t BOSS_TIME
+scoreboard players set gestrom_t BOSS_TIME -40
 scoreboard players reset gestrom_s BOSS_TIME
 scoreboard players reset gestrom_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/golem/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/golem/go.mcfunction
@@ -14,6 +14,9 @@ execute if score GolemBoss BILLGART matches 0.. run function att2:gameplay/boss/
 particle minecraft:dust{color:[1,0,0],scale:1} -1309 121 -549 1 1 0.1 0 5 force
 particle minecraft:dust{color:[1,0,0],scale:1} -1331 122 -584 0.1 1 1 0 5 force
 
+##delay time
+execute if score golem_t BOSS_TIME matches ..-1 run return run scoreboard players add golem_t BOSS_TIME 1
+
 # Music management
 execute if score GolemBoss BILLGART matches 0.. in minecraft:the_end as @a[x=-1330,y=120,z=-550,dx=55,dy=60,dz=-55,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_demiboss
 execute if score GolemBoss BILLGART matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -24,7 +27,7 @@ execute if score GolemBoss BILLGART matches 0.. in minecraft:the_end if entity @
 execute if score GolemBoss BILLGART matches 0.. in minecraft:the_end store result score 00000000-0000-009b-0000-00000000009b BILLGART run data get entity 00000000-0000-009b-0000-00000000009b Health 1
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 113 in minecraft:the_end as @a[x=-1309,y=122,z=-548,dx=-1,dy=-2,dz=0,gamemode=adventure] at @s unless entity @a[x=-1330,y=120,z=-550,dx=55,dy=60,dz=-55,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/billgart/golem/display_title
+#execute if score Mainquest SIDEQUEST matches 113 in minecraft:the_end as @a[x=-1309,y=122,z=-548,dx=-1,dy=-2,dz=0,gamemode=adventure] at @s unless entity @a[x=-1330,y=120,z=-550,dx=55,dy=60,dz=-55,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/billgart/golem/display_title
 execute if score EnterArena BILLGART matches ..0 in minecraft:the_end as @a[x=-1309,y=122,z=-548,dx=-1,dy=-2,dz=0,gamemode=adventure] at @s run function att2:gameplay/boss/billgart/golem/enter_arena
 execute if score EnterArena BILLGART matches 1.. run scoreboard players remove EnterArena BILLGART 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/golem/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/golem/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:golem {"selector":"00000000-0000-009b-0000-00000000009b",c
 bossbar set minecraft:golem style notched_12
 bossbar set minecraft:golem players @a
 bossbar set minecraft:golem color purple
-bossbar set minecraft:golem name [{text:"Golem",color:"red"}]
+bossbar set minecraft:golem name [{translate:att2.boss.name.golem,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/golem/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/golem/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset golem_t BOSS_TIME
+scoreboard players set golem_t BOSS_TIME -40
 scoreboard players reset golem_s BOSS_TIME
 scoreboard players reset golem_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/golem/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/golem/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= golem_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/billgart/golem/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/billgart/golem/time/time_show
 
-scoreboard players reset golem_t BOSS_TIME
+scoreboard players set golem_t BOSS_TIME -40
 scoreboard players reset golem_s BOSS_TIME
 scoreboard players reset golem_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/kum/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/kum/go.mcfunction
@@ -14,6 +14,9 @@ execute if score Kum SQ53 matches 0.. run function att2:gameplay/boss/billgart/k
 execute if score Kum SQ53 matches -2.. run particle minecraft:dust{color:[1,0,0],scale:1} -1533 31 -605 0 1 1 1 2 normal
 execute if score Kum SQ53 matches -2.. run particle minecraft:dust{color:[1,0,0],scale:1} -1572 29 -605 0 1 1 1 2 normal
 
+##delay time
+execute if score kum_t BOSS_TIME matches ..-1 run return run scoreboard players add kum_t BOSS_TIME 1
+
 # Music management
 execute if score Kum SQ53 matches 0.. as @a[x=-1533,y=9,z=-589,dx=-39,dy=52,dz=-32,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Kum SQ53 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -23,7 +26,7 @@ execute if score Kum SQ53 matches 0.. if entity @a[x=-1533,y=9,z=-589,dx=-39,dy=
 execute if score Kum SQ53 matches 0.. if entity @a[x=-1533,y=9,z=-589,dx=-39,dy=52,dz=-32,gamemode=adventure] store result bossbar minecraft:kum max run attribute 00000000-0000-021c-0000-00000000021c max_health get
 
 # Make challengers enters the arena
-execute if score SQ53 SIDEQUEST matches 1..99 as @a[x=-1532,y=30,z=-606,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-1533,y=9,z=-589,dx=-39,dy=52,dz=-32,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/billgart/kum/display_title
+#execute if score SQ53 SIDEQUEST matches 1..99 as @a[x=-1532,y=30,z=-606,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-1533,y=9,z=-589,dx=-39,dy=52,dz=-32,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/billgart/kum/display_title
 execute if score EnterArena SQ53 matches ..0 as @a[x=-1532,y=30,z=-606,dx=0,dy=2,dz=2,gamemode=adventure] run function att2:gameplay/boss/billgart/kum/enter_arena
 execute if score EnterArena SQ53 matches 1.. run scoreboard players remove EnterArena SQ53 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/kum/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/kum/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:kum {"selector":"00000000-0000-021c-0000-00000000021c",col
 bossbar set minecraft:kum style notched_12
 bossbar set minecraft:kum players @a
 bossbar set minecraft:kum color purple
-bossbar set minecraft:kum name [{text:"Kum",color:"red"}]
+bossbar set minecraft:kum name [{translate:att2.boss.name.kum,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/kum/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/kum/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset kum_t BOSS_TIME
+scoreboard players set kum_t BOSS_TIME -40
 scoreboard players reset kum_s BOSS_TIME
 scoreboard players reset kum_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/kum/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/kum/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= kum_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/billgart/kum/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/billgart/kum/time/time_show
 
-scoreboard players reset kum_t BOSS_TIME
+scoreboard players set kum_t BOSS_TIME -40
 scoreboard players reset kum_s BOSS_TIME
 scoreboard players reset kum_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/ulkoggumi/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/ulkoggumi/go.mcfunction
@@ -11,6 +11,9 @@
 particle minecraft:dust{color:[1,0,0],scale:1} -1137 111 -560 0.1 1 1 0 5 force
 particle minecraft:dust{color:[1,0,0],scale:1} -1134 107 -541 1 1 0.1 0 5 force
 
+##delay time
+execute if score ulkoggumi_t BOSS_TIME matches ..-1 run return run scoreboard players add ulkoggumi_t BOSS_TIME 1
+
 # Music management
 execute if score Ulkoggumi BILLGART matches 0.. in minecraft:the_end as @a[x=-1137,y=106,z=-542,dx=24,dy=7,dz=-36,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_demiboss
 execute if score Ulkoggumi BILLGART matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -20,7 +23,7 @@ execute if score Ulkoggumi BILLGART matches 0.. in minecraft:the_end if entity @
 execute if score Ulkoggumi BILLGART matches 0.. in minecraft:the_end if entity @a[x=-1137,y=106,z=-542,dx=24,dy=7,dz=-36,gamemode=adventure] store result bossbar minecraft:ulkoggumi max run attribute 00000000-0000-010b-0000-00000000010b max_health get
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 161 in minecraft:the_end as @a[x=-1138,y=110,z=-561,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-1137,y=106,z=-542,dx=24,dy=7,dz=-36,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/billgart/ulkoggumi/display_title
+#execute if score Mainquest SIDEQUEST matches 161 in minecraft:the_end as @a[x=-1138,y=110,z=-561,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-1137,y=106,z=-542,dx=24,dy=7,dz=-36,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/billgart/ulkoggumi/display_title
 execute if score EnterArena BILLGART matches ..0 in minecraft:the_end as @a[x=-1138,y=110,z=-561,dx=0,dy=2,dz=2,gamemode=adventure] run function att2:gameplay/boss/billgart/ulkoggumi/enter_arena
 execute if score EnterArena BILLGART matches 1.. run scoreboard players remove EnterArena BILLGART 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/ulkoggumi/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/ulkoggumi/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:ulkoggumi {"selector":"00000000-0000-010b-0000-00000000010
 bossbar set minecraft:ulkoggumi style notched_12
 bossbar set minecraft:ulkoggumi players @a
 bossbar set minecraft:ulkoggumi color purple
-bossbar set minecraft:ulkoggumi name [{text:"Ulkoggumi",color:"red"}]
+bossbar set minecraft:ulkoggumi name [{translate:att2.boss.name.ulkoggumi,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/ulkoggumi/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/ulkoggumi/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset ulkoggumi_t BOSS_TIME
+scoreboard players set ulkoggumi_t BOSS_TIME -40
 scoreboard players reset ulkoggumi_s BOSS_TIME
 scoreboard players reset ulkoggumi_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/billgart/ulkoggumi/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/billgart/ulkoggumi/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= ulkoggumi_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/billgart/ulkoggumi/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/billgart/ulkoggumi/time/time_show
 
-scoreboard players reset ulkoggumi_t BOSS_TIME
+scoreboard players set ulkoggumi_t BOSS_TIME -40
 scoreboard players reset ulkoggumi_s BOSS_TIME
 scoreboard players reset ulkoggumi_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/earndhel/etotsira/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/earndhel/etotsira/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:etotsira {"selector":"00000000-0000-008c-0000-00000000008a
 bossbar set minecraft:etotsira style notched_12
 bossbar set minecraft:etotsira players @a[x=30025,y=14,z=29931,dx=30,dy=5,dz=30,gamemode=adventure]
 bossbar set minecraft:etotsira color white
-bossbar set minecraft:etotsira name [{text:"Etotsira",color:"blue"}]
+bossbar set minecraft:etotsira name [{translate:att2.boss.name.etotsira,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:doom players @s
+
+##show display_title
+function att2:gameplay/boss/elcheol/doom/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/go.mcfunction
@@ -10,6 +10,9 @@
 # Particules for entrance and exit of the arena
 execute if score Doom SQ56 matches -1.. run particle minecraft:dust{color:[1,0,0],scale:1} -5229 145.5 -6293 0.25 1 0.25 1 2 normal
 
+##delay time
+execute if score doom_t BOSS_TIME matches ..-1 run return run scoreboard players add doom_t BOSS_TIME 1
+
 # Music management
 execute if score Doom SQ56 matches 0.. as @a[x=-5229,y=47,z=-6293,distance=..25,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_secretboss
 execute if score Doom SQ56 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -20,7 +23,7 @@ execute if score Doom SQ56 matches 0.. if entity @a[x=-5229,y=47,z=-6293,distanc
 execute if score Doom SQ56 matches 0.. store result score 00000000-0000-026c-0000-00000000026c SQ56 run data get entity 00000000-0000-026c-0000-00000000026c Health 1
 
 # Make challengers enters the arena
-execute if score Doom SQ56 matches -1.. if score SQ56 SIDEQUEST matches 3 as @a[x=-5229,y=144,z=-6293,dx=0,dy=2,dz=0,gamemode=adventure] at @s unless entity @a[x=-5229,y=47,z=-6293,distance=..25,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/elcheol/doom/display_title
+#execute if score Doom SQ56 matches -1.. if score SQ56 SIDEQUEST matches 3 as @a[x=-5229,y=144,z=-6293,dx=0,dy=2,dz=0,gamemode=adventure] at @s unless entity @a[x=-5229,y=47,z=-6293,distance=..25,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/elcheol/doom/display_title
 execute if score Doom SQ56 matches -1.. if score EnterArena SQ56 matches ..0 as @a[x=-5229,y=144,z=-6293,dx=0,dy=2,dz=0,gamemode=adventure] run function att2:gameplay/boss/elcheol/doom/enter_arena
 execute if score Doom SQ56 matches -1.. if score EnterArena SQ56 matches 1.. run scoreboard players remove EnterArena SQ56 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:doom {"selector":"00000000-0000-026c-0000-00000000026c",co
 bossbar set minecraft:doom style notched_12
 bossbar set minecraft:doom players @a[x=-5229,y=47,z=-6293,distance=..25,gamemode=adventure]
 bossbar set minecraft:doom color purple
-bossbar set minecraft:doom name [{text:"DooM",color:"red"}]
+bossbar set minecraft:doom name [{translate:att2.boss.name.doom,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset doom_t BOSS_TIME
+scoreboard players set doom_t BOSS_TIME -40
 scoreboard players reset doom_s BOSS_TIME
 scoreboard players reset doom_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/doom/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= doom_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/elcheol/doom/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/elcheol/doom/time/time_show
 
-scoreboard players reset doom_t BOSS_TIME
+scoreboard players set doom_t BOSS_TIME -40
 scoreboard players reset doom_s BOSS_TIME
 scoreboard players reset doom_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/korlaph/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/korlaph/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:korlaph players @s
+
+##show display_title
+function att2:gameplay/boss/elcheol/korlaph/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/korlaph/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/korlaph/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:korlaph {"selector":"00000000-0000-004c-0000-00000000004c"
 bossbar set minecraft:korlaph style notched_12
 bossbar set minecraft:korlaph players @a[x=-5111.5,y=165,z=-6755.5,distance=..15,gamemode=adventure]
 bossbar set minecraft:korlaph color purple
-bossbar set minecraft:korlaph name [{text:"Korlaph",color:"red"}]
+bossbar set minecraft:korlaph name [{translate:att2.boss.name.korlaph,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:miehanov players @s
+
+##show display_title
+function att2:gameplay/boss/elcheol/miehanov/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/go.mcfunction
@@ -10,6 +10,9 @@
 # Particules for entarance and exit of the arena
 particle minecraft:dust{color:[1,0,0],scale:1} -5614 167 -6393 2 2 0.1 0 5 force
 
+##delay time
+execute if score miehanov_t BOSS_TIME matches ..-1 run return run scoreboard players add miehanov_t BOSS_TIME 1
+
 # Music management
 execute if score Miehanov VONAHEIM matches 0.. as @a[x=-5641,y=165,z=-6342,dx=52,dy=21,dz=-51,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_demiboss
 execute if score Miehanov VONAHEIM matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -19,7 +22,7 @@ execute if score Miehanov VONAHEIM matches 0.. if entity @a[x=-5641,y=165,z=-634
 execute if score Miehanov VONAHEIM matches 0.. if entity @a[x=-5641,y=165,z=-6342,dx=52,dy=21,dz=-51,gamemode=adventure] store result bossbar minecraft:miehanov max run attribute 00000000-0000-008b-0000-00000000008b max_health get
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 113 as @a[x=-5613,y=163,z=-6388,dx=-2,dy=2,dz=-2,gamemode=adventure] at @s unless entity @a[x=-5641,y=165,z=-6342,dx=52,dy=21,dz=-51,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/elcheol/miehanov/display_title
+#execute if score Mainquest SIDEQUEST matches 113 as @a[x=-5613,y=163,z=-6388,dx=-2,dy=2,dz=-2,gamemode=adventure] at @s unless entity @a[x=-5641,y=165,z=-6342,dx=52,dy=21,dz=-51,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/elcheol/miehanov/display_title
 execute if score EnterArena VONAHEIM matches ..0 as @a[x=-5613,y=163,z=-6388,dx=-2,dy=2,dz=-2,gamemode=adventure] run function att2:gameplay/boss/elcheol/miehanov/enter_arena
 execute if score EnterArena VONAHEIM matches 1.. run scoreboard players remove EnterArena VONAHEIM 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:miehanov {"selector":"00000000-0000-008b-0000-00000000008b
 bossbar set minecraft:miehanov style notched_12
 bossbar set minecraft:miehanov players @a[x=-5641,y=165,z=-6342,dx=52,dy=21,dz=-51,gamemode=adventure]
 bossbar set minecraft:miehanov color purple
-bossbar set minecraft:miehanov name [{text:"Miehanov",color:"red"}]
+bossbar set minecraft:miehanov name [{translate:att2.boss.name.miehanov,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset miehanov_t BOSS_TIME
+scoreboard players set miehanov_t BOSS_TIME -40
 scoreboard players reset miehanov_s BOSS_TIME
 scoreboard players reset miehanov_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/miehanov/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= miehanov_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/elcheol/miehanov/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/elcheol/miehanov/time/time_show
 
-scoreboard players reset miehanov_t BOSS_TIME
+scoreboard players set miehanov_t BOSS_TIME -40
 scoreboard players reset miehanov_s BOSS_TIME
 scoreboard players reset miehanov_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/enter_arena.mcfunction
@@ -10,3 +10,6 @@ scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:ted players @s
 bossbar set minecraft:skrappy1 players @s
 bossbar set minecraft:skrappy2 players @s
+
+##show display_title
+function att2:gameplay/boss/elcheol/ted/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/go.mcfunction
@@ -11,6 +11,9 @@
 execute if score Ted SQ55 matches -2.. run particle minecraft:dust{color:[1,0,0],scale:1} -5076 97 -6198 0 2 2 1 2 normal
 execute if score Ted SQ55 matches -2.. run particle minecraft:dust{color:[1,0,0],scale:1} -5126 110.5 -6198 0 1 1 1 2 normal
 
+##delay time
+execute if score ted_t BOSS_TIME matches ..-1 run return run scoreboard players add ted_t BOSS_TIME 1
+
 # Music management
 execute if score Ted SQ55 matches 0.. as @a[x=-5076,y=91,z=-6171,dx=-50,dy=32,dz=-56,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Ted SQ55 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -29,7 +32,7 @@ execute if score Ted SQ55 matches 0.. unless entity 00000000-0000-025c-0000-0000
 execute if score Ted SQ55 matches 0.. if entity @a[x=-5076,y=91,z=-6171,dx=-50,dy=32,dz=-56,gamemode=adventure] store result bossbar minecraft:skrappy2 max run attribute 00000000-0000-025c-0000-00000000025c max_health get
 
 # Make challengers enters the arena
-execute if score SQ55 SIDEQUEST matches 1..99 as @a[x=-5075,y=95,z=-6200,dx=0,dy=4,dz=4,gamemode=adventure] at @s unless entity @a[x=-5076,y=91,z=-6171,dx=-50,dy=32,dz=-56,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/elcheol/ted/display_title
+#execute if score SQ55 SIDEQUEST matches 1..99 as @a[x=-5075,y=95,z=-6200,dx=0,dy=4,dz=4,gamemode=adventure] at @s unless entity @a[x=-5076,y=91,z=-6171,dx=-50,dy=32,dz=-56,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/elcheol/ted/display_title
 execute if score EnterArena SQ55 matches ..0 as @a[x=-5075,y=95,z=-6200,dx=0,dy=4,dz=4,gamemode=adventure] run function att2:gameplay/boss/elcheol/ted/enter_arena
 execute if score EnterArena SQ55 matches 1.. run scoreboard players remove EnterArena SQ55 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/init_bossbar.mcfunction
@@ -7,16 +7,16 @@ bossbar add minecraft:ted {"selector":"00000000-0000-023c-0000-00000000023c",col
 bossbar set minecraft:ted style notched_12
 bossbar set minecraft:ted players @a[x=-5076,y=91,z=-6171,dx=-50,dy=32,dz=-56,gamemode=adventure]
 bossbar set minecraft:ted color purple
-bossbar set minecraft:ted name [{text:"Ted",color:"red"}]
+bossbar set minecraft:ted name [{translate:att2.boss.name.ted,color:"red"}]
 
 bossbar add minecraft:skrappy1 {"selector":"00000000-0000-024c-0000-00000000024c",color:"dark_red"}
 bossbar set minecraft:skrappy1 style notched_12
 bossbar set minecraft:skrappy1 players @a[x=-5076,y=91,z=-6171,dx=-50,dy=32,dz=-56,gamemode=adventure]
 bossbar set minecraft:skrappy1 color purple
-bossbar set minecraft:skrappy1 name [{text:"Skrappy's child",color:"red"}]
+bossbar set minecraft:skrappy1 name [{translate:att2.boss.name.skrappy,color:"red"}]
 
 bossbar add minecraft:skrappy2 {"selector":"00000000-0000-025c-0000-00000000025c",color:"dark_red"}
 bossbar set minecraft:skrappy2 style notched_12
 bossbar set minecraft:skrappy2 players @a[x=-5076,y=91,z=-6171,dx=-50,dy=32,dz=-56,gamemode=adventure]
 bossbar set minecraft:skrappy2 color purple
-bossbar set minecraft:skrappy2 name [{text:"Skrappy's child",color:"red"}]
+bossbar set minecraft:skrappy2 name [{translate:att2.boss.name.skrappy,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset ted_t BOSS_TIME
+scoreboard players set ted_t BOSS_TIME -40
 scoreboard players reset ted_s BOSS_TIME
 scoreboard players reset ted_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/ted/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= ted_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/elcheol/ted/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/elcheol/ted/time/time_show
 
-scoreboard players reset ted_t BOSS_TIME
+scoreboard players set ted_t BOSS_TIME -40
 scoreboard players reset ted_s BOSS_TIME
 scoreboard players reset ted_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:vonaheim players @s
+
+##show display_title
+function att2:gameplay/boss/elcheol/vonaheim/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/go.mcfunction
@@ -12,6 +12,9 @@
 particle minecraft:dust{color:[1,0,0],scale:1.5} -5614 193.5 -6507 0.8 0.8 0 0 2 force
 particle minecraft:dust{color:[1,0,0],scale:1.5} -5614 190.5 -6529 0.8 0.8 0 0 2 force
 
+##delay time
+execute if score vonaheim_t BOSS_TIME matches ..-1 run return run scoreboard players add vonaheim_t BOSS_TIME 1
+
 # Music management
 execute if score Vonaheim VONAHEIM matches 0.. as @a[x=-5632,y=200,z=-6528,dx=36,dy=12,dz=36,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_boss
 execute if score Vonaheim VONAHEIM matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -25,7 +28,7 @@ execute if score Vonaheim VONAHEIM matches 0.. at @a[x=-5585,y=78,z=-6481,dx=-60
 execute if score Vonaheim VONAHEIM matches 0.. at @a[x=-5585,y=78,z=-6481,dx=-60,dy=2,dz=-60,gamemode=adventure] if block ~ ~-1 ~ minecraft:ice run function att2:physicmod/reg1/vonaheim/center_n/boss_player_icemelting
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 115 as @a[x=-5615,y=192,z=-6506,dx=2,dy=2,dz=0,gamemode=adventure] at @s unless entity @a[x=-5632,y=200,z=-6528,dx=36,dy=12,dz=36,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/elcheol/vonaheim/display_title
+#execute if score Mainquest SIDEQUEST matches 115 as @a[x=-5615,y=192,z=-6506,dx=2,dy=2,dz=0,gamemode=adventure] at @s unless entity @a[x=-5632,y=200,z=-6528,dx=36,dy=12,dz=36,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/elcheol/vonaheim/display_title
 execute if score EnterArena VONAHEIM matches ..0 as @a[x=-5615,y=192,z=-6506,dx=2,dy=2,dz=0] run function att2:gameplay/boss/elcheol/vonaheim/enter_arena
 execute if score EnterArena VONAHEIM matches 1.. run scoreboard players remove EnterArena VONAHEIM 1
 execute as @a[x=-5616,y=198,z=-6512,dx=4,dy=1,dz=4] at @s run tp @s ~ ~4 ~

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:vonaheim {"selector":"00000000-0000-006b-0000-00000000006b
 bossbar set minecraft:vonaheim style notched_12
 bossbar set minecraft:vonaheim players @a[x=-5632,y=200,z=-6528,dx=36,dy=12,dz=36,gamemode=adventure]
 bossbar set minecraft:vonaheim color purple
-bossbar set minecraft:vonaheim name [{text:"Vonaheim",color:"red"}]
+bossbar set minecraft:vonaheim name [{translate:att2.boss.name.vonaheim,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset vonaheim_t BOSS_TIME
+scoreboard players set vonaheim_t BOSS_TIME -40
 scoreboard players reset vonaheim_s BOSS_TIME
 scoreboard players reset vonaheim_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/elcheol/vonaheim/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= vonaheim_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/elcheol/vonaheim/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/elcheol/vonaheim/time/time_show
 
-scoreboard players reset vonaheim_t BOSS_TIME
+scoreboard players set vonaheim_t BOSS_TIME -40
 scoreboard players reset vonaheim_s BOSS_TIME
 scoreboard players reset vonaheim_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/enter_arena.mcfunction
@@ -3,6 +3,7 @@
 #Process challengers enters arena                               	#
 #####################################################################
 
+tp @a ~ ~ ~
 tp @s -5117 121 -6870
 stopsound @s
 tag @s add NoAutoMusic
@@ -10,3 +11,6 @@ scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:umbratyanth players @s
 
 function att2:gameplay/checkpoint/telluron_present/elcheol3
+
+##show display_title
+function att2:gameplay/boss/ether/umbratyanth/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/go.mcfunction
@@ -10,6 +10,9 @@
 #   -2 Boss had been finished                                     								#
 #################################################################################################
 
+##delay time
+execute if score umbratyanth_t BOSS_TIME matches ..-1 run return run scoreboard players add umbratyanth_t BOSS_TIME 1
+
 # Process go of all phases
 execute if score Boss UMBRATYANTH matches 1..2 run function att2:gameplay/boss/ether/umbratyanth/phase1/go
 execute if score Boss UMBRATYANTH matches 3 run function att2:gameplay/boss/ether/umbratyanth/phase2/go
@@ -68,7 +71,7 @@ execute if score Boss UMBRATYANTH matches -2 if score SQ46 SIDEQUEST matches 3..
 execute if score Boss UMBRATYANTH matches -2 if score SQ46 SIDEQUEST matches 3.. if entity @a[x=-5112,y=162,z=-6739,distance=..7,gamemode=adventure] unless entity @a[x=-5158,y=119,z=-6911,dx=82,dy=40,dz=82,gamemode=adventure] run particle minecraft:dust{color:[5,5,5],scale:0.5} -5112 161.75 -6739 0.3 0.3 0.3 1 10 normal
 
 # Make challengers enters the arena
-execute if score SQ46 SIDEQUEST matches 3 if entity @a[x=-5114,y=163,z=-6738,dx=4,dy=4,dz=0,gamemode=adventure] unless entity @a[x=-5158,y=119,z=-6911,dx=82,dy=40,dz=82,gamemode=adventure,tag=!Dead] as @a[distance=..100] run function att2:gameplay/boss/ether/umbratyanth/display_title
+#execute if score SQ46 SIDEQUEST matches 3 if entity @a[x=-5114,y=163,z=-6738,dx=4,dy=4,dz=0,gamemode=adventure] unless entity @a[x=-5158,y=119,z=-6911,dx=82,dy=40,dz=82,gamemode=adventure,tag=!Dead] as @a[distance=..100] run function att2:gameplay/boss/ether/umbratyanth/display_title
 execute if score Boss UMBRATYANTH matches -1.. if score EnterArena UMBRATYANTH matches ..0 as @a[x=-5114,y=163,z=-6738,dx=4,dy=4,dz=0] run function att2:gameplay/boss/ether/umbratyanth/enter_arena
 execute if score Boss UMBRATYANTH matches -1.. if score EnterArena UMBRATYANTH matches 1.. run scoreboard players remove EnterArena UMBRATYANTH 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/init_bossbar.mcfunction
@@ -3,8 +3,9 @@
 #Initialize bossbar Umbra'Tyanth								#
 #################################################################
 
+bossbar remove minecraft:umbratyanth
 bossbar add minecraft:umbratyanth {"selector":"00000000-0000-012c-0000-00000000012c",color:"dark_red"}
 bossbar set minecraft:umbratyanth style notched_12
 bossbar set minecraft:umbratyanth players @a[x=-5158,y=119,z=-6911,dx=82,dy=40,dz=82,gamemode=adventure]
 bossbar set minecraft:umbratyanth color white
-bossbar set minecraft:umbratyanth name [{text:"Umbra'Tyanth",color:"black"}]
+bossbar set minecraft:umbratyanth name [{translate:att2.boss.name.umbratyanth,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/phase1/attack/maze.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/phase1/attack/maze.mcfunction
@@ -15,5 +15,5 @@ execute if score Timer2 UMBRATYANTH matches 10 as @p[x=-5117,y=121,z=-6870] run 
 execute if score Timer2 UMBRATYANTH matches 20 run function att2:physicmod/reg1/ether/umbra_maze
 execute if score Timer2 UMBRATYANTH matches 25 run scoreboard players set Sonar UMBRATYANTH 0
 execute if score Timer2 UMBRATYANTH matches 30 as @e[type=minecraft:spider,tag=UmbraMinion,x=-5158,y=120,z=-6911,dx=82,dy=30,dz=82] at @s run tp @s ~ ~8 ~
-execute if score Timer2 UMBRATYANTH matches 50 as @a[x=-5158,y=120,z=-6911,dx=82,dy=40,dz=82,gamemode=adventure] at @s run effect give @s minecraft:wither 1000000 0 true
+execute if score Timer2 UMBRATYANTH matches 50 as @a[x=-5158,y=120,z=-6911,dx=82,dy=40,dz=82,gamemode=adventure] at @s run effect give @s minecraft:wither 10 0 true
 execute if score Timer2 UMBRATYANTH matches 750.. run function att2:gameplay/boss/ether/umbratyanth/phase1/attack_fail

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/phase1/end_phase.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/phase1/end_phase.mcfunction
@@ -9,6 +9,7 @@ scoreboard players set Timer2 UMBRATYANTH 0
 scoreboard players set Timer1 UMBRATYANTH 1
 scoreboard players set Boss UMBRATYANTH 3
 bossbar set minecraft:umbratyanth color purple
+
 execute at @a run function att2:sound/mobs/umbratyanth_attack
 execute positioned -5117 130 -6870 run function att2:summon/reg_1/umbratyanth_parts
 execute as 00000000-0000-012c-0000-00000000012c run data merge entity @s {Invulnerable:0b}

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/phase1/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/phase1/go.mcfunction
@@ -20,6 +20,9 @@
 #   1..200 ON                                						#
 #####################################################################
 
+
+attribute 00000000-0000-012c-0000-00000000012c max_health base set 1000
+
 # Minions counting
 execute if score Boss UMBRATYANTH matches 1 store result score Minions_counter UMBRATYANTH if entity @e[x=-5158,y=120,z=-6911,dx=82,dy=40,dz=82,type=minecraft:spider,tag=UmbraMinion]
 execute if score Boss UMBRATYANTH matches 1 if score Minions_counter UMBRATYANTH matches 0..29 run function att2:gameplay/boss/ether/umbratyanth/phase1/minions_counting
@@ -27,6 +30,8 @@ execute if score Boss UMBRATYANTH matches 1 if score Minions_counter UMBRATYANTH
 # Counting security if all Minions is dead
 execute if score Boss UMBRATYANTH matches 1 unless entity @e[x=-5158,y=120,z=-6911,dx=82,dy=40,dz=82,type=minecraft:spider,tag=UmbraMinion] run function att2:gameplay/boss/ether/umbratyanth/phase1/minions_counting
 
+##clear error spider
+execute if score tic TIMECOUNTER matches 1 run tp @e[x=-5158,y=115,z=-6911,dx=82,dy=-100,dz=82,type=minecraft:spider,tag=UmbraMinion] ~ 0 ~
 # Process action
 execute if score Boss UMBRATYANTH matches 1 run function att2:gameplay/boss/ether/umbratyanth/phase1/action
 

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/phase1/minions_spread.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/phase1/minions_spread.mcfunction
@@ -3,4 +3,4 @@
 #Process minions_spread                                				#
 #####################################################################
 
-spreadplayers -5117 -6870 5 25 under 121 true @e[type=minecraft:spider,tag=UmbraMinion,x=-5158,y=120,z=-6911,dx=82,dy=40,dz=82,limit=1]
+spreadplayers -5117 -6870 2 25 under 121 true @e[type=minecraft:spider,tag=UmbraMinion,x=-5158,y=120,z=-6911,dx=82,dy=40,dz=82,limit=1]

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/stop.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/stop.mcfunction
@@ -11,6 +11,7 @@ scoreboard players set @s MUSIC_TIMER 20
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:umbratyanth visible false
 bossbar remove minecraft:umbratyanth
+
 effect clear @a minecraft:jump_boost
 scoreboard players set Sonar UMBRATYANTH -1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset umbratyanth_t BOSS_TIME
+scoreboard players set umbratyanth_t BOSS_TIME -40
 scoreboard players reset umbratyanth_s BOSS_TIME
 scoreboard players reset umbratyanth_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ether/umbratyanth/time/time_over.mcfunction
@@ -23,6 +23,6 @@ scoreboard players operation test_t BOSS_TIME -= umbratyanth_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/ether/umbratyanth/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/ether/umbratyanth/time/time_show
 
-scoreboard players reset umbratyanth_t BOSS_TIME
+scoreboard players set umbratyanth_t BOSS_TIME -40
 scoreboard players reset umbratyanth_s BOSS_TIME
 scoreboard players reset umbratyanth_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/ithax/guardian/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ithax/guardian/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:guardian players @s
+
+##show display_title
+function att2:gameplay/boss/ithax/guardian/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/ithax/guardian/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ithax/guardian/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:guardian {"selector":"00000000-0000-007b-0000-00000000007b
 bossbar set minecraft:guardian style notched_12
 bossbar set minecraft:guardian players @a[x=-7451,y=133,z=-5999,dx=34,dy=16,dz=-27,gamemode=adventure]
 bossbar set minecraft:guardian color white
-bossbar set minecraft:guardian name [{text:"Guardian",color:"black"}]
+bossbar set minecraft:guardian name [{translate:att2.boss.name.guardian,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:scavenger players @s
+
+##show display_title
+function att2:gameplay/boss/kert/scavenger/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/go.mcfunction
@@ -11,6 +11,9 @@
 execute if score Scavenger SQ51 matches -2.. run particle minecraft:dust{color:[1,0,0],scale:1} -5552 53 -4577 1 1 0 1 2 normal
 execute if score Scavenger SQ51 matches -2.. run particle minecraft:dust{color:[1,0,0],scale:1} -5552 50 -4541 1 1 0 1 2 normal
 
+##delay time
+execute if score scavenger_t BOSS_TIME matches ..-1 run return run scoreboard players add scavenger_t BOSS_TIME 1
+
 # Music management
 execute if score Scavenger SQ51 matches 0.. as @a[x=-5566,y=44,z=-4577,dx=31,dy=17,dz=36,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Scavenger SQ51 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -20,7 +23,7 @@ execute if score Scavenger SQ51 matches 0.. if entity @a[x=-5566,y=44,z=-4577,dx
 execute if score Scavenger SQ51 matches 0.. if entity @a[x=-5566,y=44,z=-4577,dx=31,dy=17,dz=36,gamemode=adventure] store result bossbar minecraft:scavenger max run attribute 00000000-0000-019c-0000-00000000019c max_health get
 
 # Make challengers enters the arena
-execute if score SQ51 SIDEQUEST matches 1..99 as @a[x=-5553,y=52,z=-4578,dx=2,dy=2,dz=0,gamemode=adventure] at @s unless entity @a[x=-5566,y=44,z=-4577,dx=31,dy=17,dz=36,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/kert/scavenger/display_title
+#execute if score SQ51 SIDEQUEST matches 1..99 as @a[x=-5553,y=52,z=-4578,dx=2,dy=2,dz=0,gamemode=adventure] at @s unless entity @a[x=-5566,y=44,z=-4577,dx=31,dy=17,dz=36,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/kert/scavenger/display_title
 execute if score EnterArena SQ51 matches ..0 as @a[x=-5553,y=52,z=-4578,dx=2,dy=2,dz=0,gamemode=adventure] run function att2:gameplay/boss/kert/scavenger/enter_arena
 execute if score EnterArena SQ51 matches 1.. run scoreboard players remove EnterArena SQ51 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:scavenger {"selector":"00000000-0000-019c-0000-00000000019
 bossbar set minecraft:scavenger style notched_12
 bossbar set minecraft:scavenger players @a[x=-5566,y=44,z=-4577,dx=31,dy=17,dz=36,gamemode=adventure]
 bossbar set minecraft:scavenger color purple
-bossbar set minecraft:scavenger name [{text:"Scavenger",color:"red"}]
+bossbar set minecraft:scavenger name [{translate:att2.boss.name.scavenger,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset scavenger_t BOSS_TIME
+scoreboard players set scavenger_t BOSS_TIME -40
 scoreboard players reset scavenger_s BOSS_TIME
 scoreboard players reset scavenger_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/kert/scavenger/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= scavenger_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/kert/scavenger/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/kert/scavenger/time/time_show
 
-scoreboard players reset scavenger_t BOSS_TIME
+scoreboard players set scavenger_t BOSS_TIME -40
 scoreboard players reset scavenger_s BOSS_TIME
 scoreboard players reset scavenger_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/enter_arena.mcfunction
@@ -9,3 +9,6 @@ tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:abmup players @s
 bossbar set minecraft:nomit players @s
+
+##show display_title
+function att2:gameplay/boss/nojelanth/abmup_nomit/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/go.mcfunction
@@ -11,6 +11,9 @@
 particle minecraft:dust{color:[1,0,0],scale:1} -7620 17 -4222 1 1 0 1 2 normal
 particle minecraft:dust{color:[1,0,0],scale:1} -7617 24.5 -4173 1 1 0 1 2 normal
 
+##delay time
+execute if score abmup_nomit_t BOSS_TIME matches ..-1 run return run scoreboard players add abmup_nomit_t BOSS_TIME 1
+
 # Music management
 execute if score Abmup_Nomit SQ58 matches 0.. as @a[x=-7637,y=28,z=-4173,dx=34,dy=-15,dz=-49,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Abmup_Nomit SQ58 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -25,7 +28,7 @@ execute if score Abmup_Nomit SQ58 matches 0.. unless entity 00000000-0000-031c-0
 execute if score Abmup_Nomit SQ58 matches 0.. if entity @a[x=-7637,y=28,z=-4173,dx=34,dy=-15,dz=-49,gamemode=adventure] store result bossbar minecraft:nomit max run attribute 00000000-0000-031c-0000-00000000031c max_health get
 
 # Make challengers enters the arena
-execute if score SQ58 SIDEQUEST matches 1..99 as @a[x=-7621,y=15,z=-4223,dx=2,dy=3,dz=0,gamemode=adventure] at @s unless entity @a[x=-7637,y=28,z=-4173,dx=34,dy=-15,dz=-49,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/nojelanth/abmup_nomit/display_title
+#execute if score SQ58 SIDEQUEST matches 1..99 as @a[x=-7621,y=15,z=-4223,dx=2,dy=3,dz=0,gamemode=adventure] at @s unless entity @a[x=-7637,y=28,z=-4173,dx=34,dy=-15,dz=-49,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/nojelanth/abmup_nomit/display_title
 execute if score EnterArena SQ58 matches ..0 as @a[x=-7621,y=15,z=-4223,dx=2,dy=3,dz=0,gamemode=adventure] run function att2:gameplay/boss/nojelanth/abmup_nomit/enter_arena
 execute if score EnterArena SQ58 matches 1.. run scoreboard players remove EnterArena SQ58 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/init_bossbar.mcfunction
@@ -7,10 +7,10 @@ bossbar add minecraft:abmup {"selector":"00000000-0000-030c-0000-00000000030c",c
 bossbar set minecraft:abmup style notched_12
 bossbar set minecraft:abmup players @a[x=-7637,y=28,z=-4173,dx=34,dy=-15,dz=-49,gamemode=adventure]
 bossbar set minecraft:abmup color purple
-bossbar set minecraft:abmup name [{text:"Abmup",color:"red"}]
+bossbar set minecraft:abmup name [{translate:att2.boss.name.abmup,color:"red"}]
 
 bossbar add minecraft:nomit {"selector":"00000000-0000-031c-0000-00000000031c",color:"dark_red"}
 bossbar set minecraft:nomit style notched_12
 bossbar set minecraft:nomit players @a[x=-7637,y=28,z=-4173,dx=34,dy=-15,dz=-49,gamemode=adventure]
 bossbar set minecraft:nomit color purple
-bossbar set minecraft:nomit name [{text:"Nomit",color:"red"}]
+bossbar set minecraft:nomit name [{translate:att2.boss.name.nomit,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset abmup_nomit_t BOSS_TIME
+scoreboard players set abmup_nomit_t BOSS_TIME -40
 scoreboard players reset abmup_nomit_s BOSS_TIME
 scoreboard players reset abmup_nomit_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/abmup_nomit/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= abmup_nomit_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/nojelanth/abmup_nomit/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/nojelanth/abmup_nomit/time/time_show
 
-scoreboard players reset abmup_nomit_t BOSS_TIME
+scoreboard players set abmup_nomit_t BOSS_TIME -40
 scoreboard players reset abmup_nomit_s BOSS_TIME
 scoreboard players reset abmup_nomit_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:hive players @s
+
+##show display_title
+function att2:gameplay/boss/nojelanth/hive/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/go.mcfunction
@@ -11,6 +11,9 @@
 particle minecraft:dust{color:[1,0,0],scale:1} -7548 83.5 -4177 1 0 1 1 2 normal
 particle minecraft:dust{color:[1,0,0],scale:1} -7547 70.5 -4162 1 1 0 1 2 normal
 
+##delay time
+execute if score hive_t BOSS_TIME matches ..-1 run return run scoreboard players add hive_t BOSS_TIME 1
+
 # Sound security
 stopsound @a * minecraft:entity.bee.loop
 stopsound @a * minecraft:entity.bee.loop_aggressive
@@ -25,7 +28,7 @@ execute if score Hive SQ58 matches 0.. as @e[x=-7536,y=78,z=-4163,dx=-21,dy=-11,
 execute if score Hive SQ58 matches 0.. if entity @a[x=-7536,y=78,z=-4163,dx=-21,dy=-11,dz=-24,gamemode=adventure] store result bossbar minecraft:hive value run scoreboard players get Bees_count SQ58
 
 # Make challengers enters the arena
-execute if score SQ58 SIDEQUEST matches 1..99 as @a[x=-7549,y=84,z=-4176,dx=2,dy=0,dz=-2,gamemode=adventure] at @s unless entity @a[x=-7536,y=78,z=-4163,dx=-21,dy=-11,dz=-24,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/nojelanth/hive/display_title
+#execute if score SQ58 SIDEQUEST matches 1..99 as @a[x=-7549,y=84,z=-4176,dx=2,dy=0,dz=-2,gamemode=adventure] at @s unless entity @a[x=-7536,y=78,z=-4163,dx=-21,dy=-11,dz=-24,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/nojelanth/hive/display_title
 execute if score EnterArena SQ58 matches ..0 as @a[x=-7549,y=84,z=-4176,dx=2,dy=0,dz=-2,gamemode=adventure] run function att2:gameplay/boss/nojelanth/hive/enter_arena
 execute if score EnterArena SQ58 matches 1.. run scoreboard players remove EnterArena SQ58 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/init_bossbar.mcfunction
@@ -7,5 +7,5 @@ bossbar add minecraft:hive {text:"Hive",color:"dark_red"}
 bossbar set minecraft:hive style notched_12
 bossbar set minecraft:hive players @a[x=-7536,y=78,z=-4163,dx=-21,dy=-11,dz=-24,gamemode=adventure]
 bossbar set minecraft:hive color purple
-bossbar set minecraft:hive name [{text:"Hive",color:"red"}]
+bossbar set minecraft:hive name [{translate:att2.boss.name.hive,color:"red"}]
 bossbar set minecraft:hive max 50

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset hive_t BOSS_TIME
+scoreboard players set hive_t BOSS_TIME -40
 scoreboard players reset hive_s BOSS_TIME
 scoreboard players reset hive_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/hive/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= hive_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/nojelanth/hive/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/nojelanth/hive/time/time_show
 
-scoreboard players reset hive_t BOSS_TIME
+scoreboard players set hive_t BOSS_TIME -40
 scoreboard players reset hive_s BOSS_TIME
 scoreboard players reset hive_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/enter_arena1.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/enter_arena1.mcfunction
@@ -12,3 +12,6 @@ bossbar set minecraft:subject0135 players @s
 bossbar set minecraft:subject0257 players @s
 bossbar set minecraft:subject0312 players @s
 bossbar set minecraft:subject0482 players @s
+
+##show display_title
+function att2:gameplay/boss/nojelanth/subjects/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/enter_arena2.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/enter_arena2.mcfunction
@@ -12,3 +12,6 @@ bossbar set minecraft:subject0135 players @s
 bossbar set minecraft:subject0257 players @s
 bossbar set minecraft:subject0312 players @s
 bossbar set minecraft:subject0482 players @s
+
+##show display_title
+function att2:gameplay/boss/nojelanth/subjects/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/enter_arena3.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/enter_arena3.mcfunction
@@ -12,3 +12,6 @@ bossbar set minecraft:subject0135 players @s
 bossbar set minecraft:subject0257 players @s
 bossbar set minecraft:subject0312 players @s
 bossbar set minecraft:subject0482 players @s
+
+##show display_title
+function att2:gameplay/boss/nojelanth/subjects/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/enter_arena4.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/enter_arena4.mcfunction
@@ -12,3 +12,6 @@ bossbar set minecraft:subject0135 players @s
 bossbar set minecraft:subject0257 players @s
 bossbar set minecraft:subject0312 players @s
 bossbar set minecraft:subject0482 players @s
+
+##show display_title
+function att2:gameplay/boss/nojelanth/subjects/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/go.mcfunction
@@ -15,6 +15,9 @@ particle minecraft:dust{color:[1,0,0],scale:1} -7431.0 114.0 -4358 0.7 0.7 0.1 0
 particle minecraft:dust{color:[1,0,0],scale:1} -7415 110 -4377 0.1 0.7 0.7 0 2 normal
 particle minecraft:dust{color:[1,0,0],scale:1} -7434 110 -4396 0.7 0.7 0.1 0 2 normal
 
+##delay time
+execute if score subjects_t BOSS_TIME matches ..-1 run return run scoreboard players add subjects_t BOSS_TIME 1
+
 # Music management
 execute if score Subjects NOJELANTH matches 0.. as @a[x=-7452,y=115,z=-4359,dx=36,dy=-6,dz=-36,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_demiboss
 execute if score Subjects NOJELANTH matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -38,10 +41,10 @@ execute if score Subjects NOJELANTH matches 0.. unless entity 00000000-0000-021b
 execute if score Subjects NOJELANTH matches 0.. if entity @a[x=-7452,y=115,z=-4359,dx=36,dy=-6,dz=-36,gamemode=adventure] store result bossbar minecraft:subject0482 max run attribute 00000000-0000-021b-0000-00000000021b max_health get
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 238 as @a[x=-7432,y=113,z=-4357,dx=1,dy=1,dz=0,gamemode=adventure] at @s unless entity @a[x=-7452,y=115,z=-4359,dx=37,dy=-6,dz=-37,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/nojelanth/subjects/display_title
-execute if score Mainquest SIDEQUEST matches 238 as @a[x=-7437,y=113,z=-4397,dx=1,dy=1,dz=0,gamemode=adventure] at @s unless entity @a[x=-7452,y=115,z=-4359,dx=37,dy=-6,dz=-37,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/nojelanth/subjects/display_title
-execute if score Mainquest SIDEQUEST matches 238 as @a[x=-7414,y=113,z=-4375,dx=0,dy=1,dz=1,gamemode=adventure] at @s unless entity @a[x=-7452,y=115,z=-4359,dx=37,dy=-6,dz=-37,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/nojelanth/subjects/display_title
-execute if score Mainquest SIDEQUEST matches 238 as @a[x=-7454,y=113,z=-4380,dx=1,dy=1,dz=1,gamemode=adventure] at @s unless entity @a[x=-7452,y=115,z=-4359,dx=37,dy=-6,dz=-37,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/nojelanth/subjects/display_title
+#execute if score Mainquest SIDEQUEST matches 238 as @a[x=-7432,y=113,z=-4357,dx=1,dy=1,dz=0,gamemode=adventure] at @s unless entity @a[x=-7452,y=115,z=-4359,dx=37,dy=-6,dz=-37,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/nojelanth/subjects/display_title
+#execute if score Mainquest SIDEQUEST matches 238 as @a[x=-7437,y=113,z=-4397,dx=1,dy=1,dz=0,gamemode=adventure] at @s unless entity @a[x=-7452,y=115,z=-4359,dx=37,dy=-6,dz=-37,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/nojelanth/subjects/display_title
+#execute if score Mainquest SIDEQUEST matches 238 as @a[x=-7414,y=113,z=-4375,dx=0,dy=1,dz=1,gamemode=adventure] at @s unless entity @a[x=-7452,y=115,z=-4359,dx=37,dy=-6,dz=-37,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/nojelanth/subjects/display_title
+#execute if score Mainquest SIDEQUEST matches 238 as @a[x=-7454,y=113,z=-4380,dx=1,dy=1,dz=1,gamemode=adventure] at @s unless entity @a[x=-7452,y=115,z=-4359,dx=37,dy=-6,dz=-37,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/nojelanth/subjects/display_title
 execute if score EnterArena NOJELANTH matches ..0 as @a[x=-7432,y=113,z=-4357,dx=1,dy=1,dz=0,gamemode=adventure] run function att2:gameplay/boss/nojelanth/subjects/enter_arena1
 execute if score EnterArena NOJELANTH matches ..0 as @a[x=-7437,y=113,z=-4397,dx=1,dy=1,dz=0,gamemode=adventure] run function att2:gameplay/boss/nojelanth/subjects/enter_arena2
 execute if score EnterArena NOJELANTH matches ..0 as @a[x=-7414,y=113,z=-4375,dx=0,dy=1,dz=1,gamemode=adventure] run function att2:gameplay/boss/nojelanth/subjects/enter_arena3

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/init_bossbar.mcfunction
@@ -7,22 +7,22 @@ bossbar add minecraft:subject0135 {"selector":"00000000-0000-018b-0000-000000000
 bossbar set minecraft:subject0135 style notched_12
 bossbar set minecraft:subject0135 players @a[x=-7452,y=115,z=-4359,dx=36,dy=-6,dz=-36,gamemode=adventure]
 bossbar set minecraft:subject0135 color purple
-bossbar set minecraft:subject0135 name [{text:"Subject0135",color:"red"}]
+bossbar set minecraft:subject0135 name [{translate:att2.boss.name.subject0135,color:"red"}]
 
 bossbar add minecraft:subject0257 {"selector":"00000000-0000-019b-0000-00000000019b",color:"dark_red"}
 bossbar set minecraft:subject0257 style notched_12
 bossbar set minecraft:subject0257 players @a[x=-7452,y=115,z=-4359,dx=36,dy=-6,dz=-36,gamemode=adventure]
 bossbar set minecraft:subject0257 color purple
-bossbar set minecraft:subject0257 name [{text:"Subject0257",color:"red"}]
+bossbar set minecraft:subject0257 name [{translate:att2.boss.name.subject0257,color:"red"}]
 
 bossbar add minecraft:subject0312 {"selector":"00000000-0000-020b-0000-00000000020b",color:"dark_red"}
 bossbar set minecraft:subject0312 style notched_12
 bossbar set minecraft:subject0312 players @a[x=-7452,y=115,z=-4359,dx=36,dy=-6,dz=-36,gamemode=adventure]
 bossbar set minecraft:subject0312 color purple
-bossbar set minecraft:subject0312 name [{text:"Subject0312",color:"red"}]
+bossbar set minecraft:subject0312 name [{translate:att2.boss.name.subject0312,color:"red"}]
 
 bossbar add minecraft:subject0482 {"selector":"00000000-0000-021b-0000-00000000021b",color:"dark_red"}
 bossbar set minecraft:subject0482 style notched_12
 bossbar set minecraft:subject0482 players @a[x=-7452,y=115,z=-4359,dx=36,dy=-6,dz=-36,gamemode=adventure]
 bossbar set minecraft:subject0482 color purple
-bossbar set minecraft:subject0482 name [{text:"Subject0482",color:"red"}]
+bossbar set minecraft:subject0482 name [{translate:att2.boss.name.subject0312,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset subjects_t BOSS_TIME
+scoreboard players set subjects_t BOSS_TIME -40
 scoreboard players reset subjects_s BOSS_TIME
 scoreboard players reset subjects_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/subjects/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= subjects_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/nojelanth/subjects/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/nojelanth/subjects/time/time_show
 
-scoreboard players reset subjects_t BOSS_TIME
+scoreboard players set subjects_t BOSS_TIME -40
 scoreboard players reset subjects_s BOSS_TIME
 scoreboard players reset subjects_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:torkant players @s
+
+##show display_title
+function att2:gameplay/boss/nojelanth/torkant/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/go.mcfunction
@@ -11,6 +11,9 @@
 particle minecraft:dust{color:[1,0,0],scale:1} -5513 35 -4139 3 0 3 1 20 normal
 particle minecraft:dust{color:[1,0,0],scale:1} -5515 19 -4164 -2 2 0 1 20 normal
 
+##delay time
+execute if score torkant_t BOSS_TIME matches ..-1 run return run scoreboard players add torkant_t BOSS_TIME 1
+
 # Sound security
 stopsound @a * minecraft:block.bubble_column.bubble_pop
 stopsound @a * minecraft:block.bubble_column.whirlpool_inside
@@ -27,7 +30,7 @@ execute if score Torkant SQ52 matches 0.. if entity @a[x=-5532,y=34,z=-4164,dx=3
 execute if score Torkant SQ52 matches 0.. if entity @a[x=-5532,y=34,z=-4164,dx=34,dy=-31,dz=44,gamemode=adventure] store result bossbar minecraft:torkant max run attribute 00000000-0000-020c-0000-00000000020c max_health get
 
 # Make challengers enters the arena
-execute if score SQ52 SIDEQUEST matches 1..99 as @a[x=-5514,y=36,z=-4140,dx=3,dy=0,dz=3,gamemode=adventure] at @s unless entity @a[x=-5532,y=34,z=-4164,dx=34,dy=-31,dz=44,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/nojelanth/torkant/display_title
+#execute if score SQ52 SIDEQUEST matches 1..99 as @a[x=-5514,y=36,z=-4140,dx=3,dy=0,dz=3,gamemode=adventure] at @s unless entity @a[x=-5532,y=34,z=-4164,dx=34,dy=-31,dz=44,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/nojelanth/torkant/display_title
 execute if score EnterArena SQ52 matches ..0 as @a[x=-5514,y=36,z=-4140,dx=3,dy=0,dz=3,gamemode=adventure] run function att2:gameplay/boss/nojelanth/torkant/enter_arena
 execute if score EnterArena SQ52 matches 1.. run scoreboard players remove EnterArena SQ52 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:torkant {"selector":"00000000-0000-020c-0000-00000000020c"
 bossbar set minecraft:torkant style notched_12
 bossbar set minecraft:torkant players @a[x=-5532,y=34,z=-4164,dx=34,dy=-31,dz=44,gamemode=adventure]
 bossbar set minecraft:torkant color purple
-bossbar set minecraft:torkant name [{text:"Torkant",color:"red"}]
+bossbar set minecraft:torkant name [{translate:att2.boss.name.torkant,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset torkant_t BOSS_TIME
+scoreboard players set torkant_t BOSS_TIME -40
 scoreboard players reset torkant_s BOSS_TIME
 scoreboard players reset torkant_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/nojelanth/torkant/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= torkant_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/nojelanth/torkant/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/nojelanth/torkant/time/time_show
 
-scoreboard players reset torkant_t BOSS_TIME
+scoreboard players set torkant_t BOSS_TIME -40
 scoreboard players reset torkant_s BOSS_TIME
 scoreboard players reset torkant_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:aozathreyon players @s
+
+##show display_title
+function att2:gameplay/boss/ouranos/aozathreyon/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/go.mcfunction
@@ -13,6 +13,9 @@ execute if score Aozathreyon OURANOS matches 0.. run function att2:gameplay/boss
 # Particules for entrance the arena
 particle minecraft:dust{color:[1,0,0],scale:1} 7316 178 6577 0.1 2 2 0 5 normal
 
+##delay time
+execute if score aozathreyon_t BOSS_TIME matches ..-1 run return run scoreboard players add aozathreyon_t BOSS_TIME 1
+
 # Music management
 execute if score Aozathreyon OURANOS matches 0.. as @a[x=7316,y=154,z=6554,dx=-46,dy=48,dz=46,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_demiboss
 execute if score Aozathreyon OURANOS matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -22,7 +25,7 @@ execute if score Aozathreyon OURANOS matches 0.. if entity @a[x=7316,y=154,z=655
 execute if score Aozathreyon OURANOS matches 0.. if entity @a[x=7316,y=154,z=6554,dx=-46,dy=48,dz=46,gamemode=adventure] store result bossbar minecraft:aozathreyon max run attribute 00000000-0000-015b-0000-00000000015b max_health get
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 206 as @a[x=7317,y=175,z=6580,dx=0,dy=6,dz=-6,gamemode=adventure] at @s unless entity @a[x=7316,y=154,z=6554,dx=-46,dy=48,dz=46,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/ouranos/aozathreyon/display_title
+#execute if score Mainquest SIDEQUEST matches 206 as @a[x=7317,y=175,z=6580,dx=0,dy=6,dz=-6,gamemode=adventure] at @s unless entity @a[x=7316,y=154,z=6554,dx=-46,dy=48,dz=46,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/ouranos/aozathreyon/display_title
 execute if score EnterArena OURANOS matches ..0 as @a[x=7317,y=175,z=6580,dx=0,dy=6,dz=-6,gamemode=adventure] run function att2:gameplay/boss/ouranos/aozathreyon/enter_arena
 execute if score EnterArena OURANOS matches 1.. run scoreboard players remove EnterArena OURANOS 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:aozathreyon {"selector":"00000000-0000-015b-0000-000000000
 bossbar set minecraft:aozathreyon style notched_12
 bossbar set minecraft:aozathreyon players @a[x=7316,y=154,z=6554,dx=-46,dy=48,dz=46,gamemode=adventure]
 bossbar set minecraft:aozathreyon color purple
-bossbar set minecraft:aozathreyon name [{text:"Aozathreyon",color:"red"}]
+bossbar set minecraft:aozathreyon name [{translate:att2.boss.name.aozathreyon,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset aozathreyon_t BOSS_TIME
+scoreboard players set aozathreyon_t BOSS_TIME -40
 scoreboard players reset aozathreyon_s BOSS_TIME
 scoreboard players reset aozathreyon_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/aozathreyon/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= aozathreyon_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/ouranos/aozathreyon/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/ouranos/aozathreyon/time/time_show
 
-scoreboard players reset aozathreyon_t BOSS_TIME
+scoreboard players set aozathreyon_t BOSS_TIME -40
 scoreboard players reset aozathreyon_s BOSS_TIME
 scoreboard players reset aozathreyon_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:naer players @s
+
+##show display_title
+function att2:gameplay/boss/ouranos/naer/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/go.mcfunction
@@ -13,6 +13,9 @@ particle minecraft:dust{color:[1,0,0],scale:1} 7710 183.5 6091 1 1.5 0.1 0 5 nor
 particle minecraft:dust{color:[1,0,0],scale:1} 7704 183.5 5981 1 1.5 0.1 0 5 normal
 particle minecraft:dust{color:[1,0,0],scale:1} 7710 183.5 5981 1 1.5 0.1 0 5 normal
 
+##delay time
+execute if score naer_t BOSS_TIME matches ..-1 run return run scoreboard players add naer_t BOSS_TIME 1
+
 # Music management
 execute if score Naër OURANOS matches 0.. as @a[x=7699,y=182,z=6091,dx=16,dy=9,dz=-110,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_demiboss
 execute if score Naër OURANOS matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -22,7 +25,7 @@ execute if score Naër OURANOS matches 0.. if entity @a[x=7699,y=182,z=6091,dx=1
 execute if score Naër OURANOS matches 0.. if entity @a[x=7699,y=182,z=6091,dx=16,dy=9,dz=-110,gamemode=adventure] store result bossbar minecraft:naer max run attribute 00000000-0000-016b-0000-00000000016b max_health get
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 209 as @a[x=7711,y=182,z=6092,dx=-8,dy=3,dz=0,gamemode=adventure] at @s unless entity @a[x=7699,y=182,z=6091,dx=16,dy=9,dz=-110,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/ouranos/naer/display_title
+#execute if score Mainquest SIDEQUEST matches 209 as @a[x=7711,y=182,z=6092,dx=-8,dy=3,dz=0,gamemode=adventure] at @s unless entity @a[x=7699,y=182,z=6091,dx=16,dy=9,dz=-110,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/ouranos/naer/display_title
 execute if score EnterArena OURANOS matches ..0 as @a[x=7711,y=182,z=6092,dx=-8,dy=3,dz=0,gamemode=adventure] run function att2:gameplay/boss/ouranos/naer/enter_arena
 execute if score EnterArena OURANOS matches 1.. run scoreboard players remove EnterArena OURANOS 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:naer {"selector":"00000000-0000-016b-0000-00000000016b",co
 bossbar set minecraft:naer style notched_12
 bossbar set minecraft:naer players @a[x=7699,y=182,z=6091,dx=16,dy=9,dz=-110,gamemode=adventure]
 bossbar set minecraft:naer color purple
-bossbar set minecraft:naer name [{text:"Naër",color:"red"}]
+bossbar set minecraft:naer name [{translate:att2.boss.name.naer,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset naer_t BOSS_TIME
+scoreboard players set naer_t BOSS_TIME -40
 scoreboard players reset naer_s BOSS_TIME
 scoreboard players reset naer_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/naer/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= naer_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/ouranos/naer/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/ouranos/naer/time/time_show
 
-scoreboard players reset naer_t BOSS_TIME
+scoreboard players set naer_t BOSS_TIME -40
 scoreboard players reset naer_s BOSS_TIME
 scoreboard players reset naer_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/ouran/phase1/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/ouran/phase1/init_bossbar.mcfunction
@@ -7,22 +7,22 @@ bossbar add minecraft:ouranlackey1 {"selector":"00000000-0000-017b-0000-00000000
 bossbar set minecraft:ouranlackey1 style notched_12
 bossbar set minecraft:ouranlackey1 players @a[scores={DIMENSION=4..5}]
 bossbar set minecraft:ouranlackey1 color purple
-bossbar set minecraft:ouranlackey1 name [{text:"Lackey",color:"red"}]
+bossbar set minecraft:ouranlackey1 name [{translate:att2.boss.name.ouranlackey,color:"red"}]
 
 bossbar add minecraft:ouranlackey2 {"selector":"00000000-0000-017b-0000-00000000002b",color:"dark_red"}
 bossbar set minecraft:ouranlackey2 style notched_12
 bossbar set minecraft:ouranlackey2 players @a[scores={DIMENSION=4..5}]
 bossbar set minecraft:ouranlackey2 color purple
-bossbar set minecraft:ouranlackey2 name [{text:"Lackey",color:"red"}]
+bossbar set minecraft:ouranlackey2 name [{translate:att2.boss.name.ouranlackey,color:"red"}]
 
 bossbar add minecraft:ouranlackey3 {"selector":"00000000-0000-017b-0000-00000000003b",color:"dark_red"}
 bossbar set minecraft:ouranlackey3 style notched_12
 bossbar set minecraft:ouranlackey3 players @a[scores={DIMENSION=4..5}]
 bossbar set minecraft:ouranlackey3 color purple
-bossbar set minecraft:ouranlackey3 name [{text:"Lackey",color:"red"}]
+bossbar set minecraft:ouranlackey3 name [{translate:att2.boss.name.ouranlackey,color:"red"}]
 
 bossbar add minecraft:ouranlackey4 {"selector":"00000000-0000-017b-0000-00000000004b",color:"dark_red"}
 bossbar set minecraft:ouranlackey4 style notched_12
 bossbar set minecraft:ouranlackey4 players @a[scores={DIMENSION=4..5}]
 bossbar set minecraft:ouranlackey4 color purple
-bossbar set minecraft:ouranlackey4 name [{text:"Lackey",color:"red"}]
+bossbar set minecraft:ouranlackey4 name [{translate:att2.boss.name.ouranlackey,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/ouran/phase2/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/ouran/phase2/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:swarm {"selector":"00000000-0000-017b-0000-00000000005b",c
 bossbar set minecraft:swarm style notched_12
 bossbar set minecraft:swarm players @a[scores={DIMENSION=4..5}]
 bossbar set minecraft:swarm color white
-bossbar set minecraft:swarm name [{text:"Swarm",color:"white"}]
+bossbar set minecraft:swarm name [{translate:att2.boss.name.swarm,color:"white"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/ouran/phase3/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/ouran/phase3/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:ouran {"selector":"00000000-0000-017b-0000-00000000017b",c
 bossbar set minecraft:ouran style notched_12
 bossbar set minecraft:ouran players @a[scores={DIMENSION=4..5}]
 bossbar set minecraft:ouran color yellow
-bossbar set minecraft:ouran name [{text:"Ouran",color:"gold"}]
+bossbar set minecraft:ouran name [{translate:att2.boss.name.ouran,color:"gold"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/somniophages/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/somniophages/go.mcfunction
@@ -14,12 +14,15 @@ execute if score Somniophages SQ48 matches 0.. run function att2:gameplay/boss/o
 particle minecraft:dust{color:[1,0,0],scale:1} 6657.5 149.5 7058.0 0.1 1 1 0 2 normal
 particle minecraft:dust{color:[1,0,0],scale:1} 6748 129 7067 0.1 1 1 0 1 normal
 
+##delay time
+execute if score somniophages_t BOSS_TIME matches ..-1 run return run scoreboard players add somniophages_t BOSS_TIME 1
+
 # Music management
 execute if score Somniophages SQ48 matches 0.. as @a[x=6657,y=2,z=7013,dx=91,dy=250,dz=117,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Somniophages SQ48 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
 
 # Make challengers enters the arena
-execute if score SQ48 SIDEQUEST matches 1..99 as @a[x=6656,y=148,z=7056,dx=0,dy=3,dz=3,gamemode=adventure] at @s unless entity @a[x=6657,y=2,z=7013,dx=91,dy=250,dz=117,gamemode=adventure,tag=!Dead] as @a[distance=..100] run function att2:gameplay/boss/ouranos/somniophages/display_title
+#execute if score SQ48 SIDEQUEST matches 1..99 as @a[x=6656,y=148,z=7056,dx=0,dy=3,dz=3,gamemode=adventure] at @s unless entity @a[x=6657,y=2,z=7013,dx=91,dy=250,dz=117,gamemode=adventure,tag=!Dead] as @a[distance=..100] run function att2:gameplay/boss/ouranos/somniophages/display_title
 execute if score EnterArena SQ48 matches ..0 as @a[x=6656,y=148,z=7056,dx=0,dy=3,dz=3,gamemode=adventure] run function att2:gameplay/boss/ouranos/somniophages/enter_arena
 execute if score EnterArena SQ48 matches 1.. run scoreboard players remove EnterArena SQ48 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/somniophages/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/somniophages/init_bossbar.mcfunction
@@ -7,7 +7,7 @@ bossbar add minecraft:somniophages {text:"Somniophages",color:"dark_red"}
 bossbar set minecraft:somniophages style notched_12
 bossbar set minecraft:somniophages players @a
 bossbar set minecraft:somniophages color purple
-bossbar set minecraft:somniophages name [{text:"Somniophages",color:"red"}]
+bossbar set minecraft:somniophages name [{translate:att2.boss.name.somniophages,color:"red"}]
 bossbar set minecraft:somniophages max 10
 
 #bossbar add minecraft:somniophage1 {"selector":"00000000-0000-014c-0000-00000000014c",color:"dark_red"}

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/somniophages/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/somniophages/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset somniophages_t BOSS_TIME
+scoreboard players set somniophages_t BOSS_TIME -40
 scoreboard players reset somniophages_s BOSS_TIME
 scoreboard players reset somniophages_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/ouranos/somniophages/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/ouranos/somniophages/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= somniophages_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/ouranos/somniophages/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/ouranos/somniophages/time/time_show
 
-scoreboard players reset somniophages_t BOSS_TIME
+scoreboard players set somniophages_t BOSS_TIME -40
 scoreboard players reset somniophages_s BOSS_TIME
 scoreboard players reset somniophages_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:owlkar players @s
+
+##show display_title
+function att2:gameplay/boss/owsastr/owlkar/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/go.mcfunction
@@ -17,6 +17,9 @@ particle minecraft:end_rod -5037 79 -4368 0.1 5 0.1 0 5
 particle minecraft:end_rod -5063 79 -4368 0.1 5 0.1 0 5
 particle minecraft:end_rod -5063 81 -4394 0.1 5 0.1 0 5
 
+##delay time
+execute if score owlkar_t BOSS_TIME matches ..-1 run return run scoreboard players add owlkar_t BOSS_TIME 1
+
 # Music management
 execute if score Owlkar OWSASTR matches 0.. as @a[x=-5073,y=71,z=-4404,dx=46,dy=10,dz=46,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_boss
 execute if score Owlkar OWSASTR matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -36,7 +39,7 @@ execute if score Owlkar_button_wn OWSASTR matches 0 run function att2:gameplay/b
 execute if score Owlkar_button_wn OWSASTR matches 1 run function att2:gameplay/boss/owsastr/owlkar/mirror_wn_particle_in
 
 # Make challengers enters the arena (unless ray are not going to it)
-execute if score Mainquest SIDEQUEST matches 26 if score mech1 OWSASTR matches 7 if score wingN OWSASTR matches 3 as @a[x=-5025,y=76,z=-4383,dx=0,dy=3,dz=4,gamemode=adventure] at @s unless entity @a[x=-5073,y=71,z=-4404,dx=46,dy=10,dz=46,gamemode=adventure] as @a[distance=..30] run function att2:gameplay/boss/owsastr/owlkar/display_title
+#execute if score Mainquest SIDEQUEST matches 26 if score mech1 OWSASTR matches 7 if score wingN OWSASTR matches 3 as @a[x=-5025,y=76,z=-4383,dx=0,dy=3,dz=4,gamemode=adventure] at @s unless entity @a[x=-5073,y=71,z=-4404,dx=46,dy=10,dz=46,gamemode=adventure] as @a[distance=..30] run function att2:gameplay/boss/owsastr/owlkar/display_title
 execute if score EnterArena OWSASTR matches ..0 if score mech1 OWSASTR matches 7 if score wingN OWSASTR matches 3 unless score Mainquest SIDEQUEST matches 27 as @a[x=-5025,y=76,z=-4383,dx=0,dy=3,dz=4] run function att2:gameplay/boss/owsastr/owlkar/enter_arena
 execute if score EnterArena OWSASTR matches 1.. run scoreboard players remove EnterArena OWSASTR 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:owlkar {"selector":"@e[type=minecraft:endermite,nbt={UUID:
 bossbar set minecraft:owlkar style notched_12
 bossbar set minecraft:owlkar players @a[x=-5073,y=71,z=-4404,dx=46,dy=10,dz=46,gamemode=adventure]
 bossbar set minecraft:owlkar color purple
-bossbar set minecraft:owlkar name [{text:"Owlkär",color:"red"}]
+bossbar set minecraft:owlkar name [{translate:att2.boss.name.owlkar,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset owlkar_t BOSS_TIME
+scoreboard players set owlkar_t BOSS_TIME -40
 scoreboard players reset owlkar_s BOSS_TIME
 scoreboard players reset owlkar_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/owsastr/owlkar/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= owlkar_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/owsastr/owlkar/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/owsastr/owlkar/time/time_show
 
-scoreboard players reset owlkar_t BOSS_TIME
+scoreboard players set owlkar_t BOSS_TIME -40
 scoreboard players reset owlkar_s BOSS_TIME
 scoreboard players reset owlkar_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/enter_arena.mcfunction
@@ -9,3 +9,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:shadow players @s
+
+##show display_title
+function att2:gameplay/boss/schestrown/shadow/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/go.mcfunction
@@ -18,6 +18,9 @@ execute if score Shadow SQ38 matches 0.. if score ShadowSound SQ38 matches 300..
 execute if score SQ38 SIDEQUEST matches 3.. run particle minecraft:dust{color:[1,0,0],scale:1} -4362 55 -5054 0.1 1 1 0 3 normal
 execute if score SQ38 SIDEQUEST matches 3.. run particle minecraft:dust{color:[1,0,0],scale:1} -4388 55 -5054 0.1 1 1 0 3 normal
 
+##delay time
+execute if score shadow_t BOSS_TIME matches ..-1 run return run scoreboard players add shadow_t BOSS_TIME 1
+
 # Music management
 execute if score Shadow SQ38 matches 0.. as @a[x=-4362,y=42,z=-5041,dx=-26,dy=24,dz=-56,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_secretboss
 execute if score Shadow SQ38 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -27,7 +30,7 @@ execute if score Shadow SQ38 matches 0.. if entity @a[x=-4362,y=42,z=-5041,dx=-2
 execute if score Shadow SQ38 matches 0.. if entity @a[x=-4362,y=42,z=-5041,dx=-26,dy=24,dz=-56,gamemode=adventure] store result bossbar minecraft:shadow max run attribute 00000000-0000-008c-0000-00000000008c max_health get
 
 # Make challengers enters the arena
-execute if score SQ38 SIDEQUEST matches 3.. as @a[x=-4389,y=54,z=-5055,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-4362,y=42,z=-5041,dx=-26,dy=24,dz=-56,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/schestrown/shadow/display_title
+#execute if score SQ38 SIDEQUEST matches 3.. as @a[x=-4389,y=54,z=-5055,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-4362,y=42,z=-5041,dx=-26,dy=24,dz=-56,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/schestrown/shadow/display_title
 execute if score SQ38 SIDEQUEST matches 3.. if score EnterArena SQ38 matches ..0 as @a[x=-4389,y=54,z=-5055,dx=0,dy=2,dz=2,gamemode=adventure] run function att2:gameplay/boss/schestrown/shadow/enter_arena
 execute if score SQ38 SIDEQUEST matches 3.. if score EnterArena SQ38 matches 1.. run scoreboard players remove EnterArena SQ38 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:shadow {"selector":"00000000-0000-008c-0000-00000000008c",
 bossbar set minecraft:shadow style notched_12
 bossbar set minecraft:shadow players @a[x=-4362,y=42,z=-5041,dx=-26,dy=24,dz=-56,gamemode=adventure]
 bossbar set minecraft:shadow color purple
-bossbar set minecraft:shadow name [{text:"Shadow",color:"black"}]
+bossbar set minecraft:shadow name [{translate:att2.boss.name.shadow,color:"black"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset shadow_t BOSS_TIME
+scoreboard players set shadow_t BOSS_TIME -40
 scoreboard players reset shadow_s BOSS_TIME
 scoreboard players reset shadow_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/schestrown/shadow/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= shadow_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/schestrown/shadow/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/schestrown/shadow/time/time_show
 
-scoreboard players reset shadow_t BOSS_TIME
+scoreboard players set shadow_t BOSS_TIME -40
 scoreboard players reset shadow_s BOSS_TIME
 scoreboard players reset shadow_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:sphere9 {"selector":"00000000-0000-022b-0000-00000000009b"
 bossbar set minecraft:sphere9 style notched_12
 bossbar set minecraft:sphere9 players @a
 bossbar set minecraft:sphere9 color white
-bossbar set minecraft:sphere9 name [{text:"⬤",color:"white"}]
+bossbar set minecraft:sphere9 name [{translate:att2.boss.name.sphere,color:"white"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere1/spawn.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere1/spawn.mcfunction
@@ -13,4 +13,4 @@ bossbar add minecraft:sphere1 {"selector":"00000000-0000-022b-0000-00000000001b"
 bossbar set minecraft:sphere1 style notched_12
 bossbar set minecraft:sphere1 players @a
 bossbar set minecraft:sphere1 color purple
-bossbar set minecraft:sphere1 name [{text:"☼",color:"red"}]
+bossbar set minecraft:sphere1 name [{translate:att2.boss.name.sphere1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere2/spawn.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere2/spawn.mcfunction
@@ -13,4 +13,4 @@ bossbar add minecraft:sphere2 {"selector":"00000000-0000-022b-0000-00000000002b"
 bossbar set minecraft:sphere2 style notched_12
 bossbar set minecraft:sphere2 players @a
 bossbar set minecraft:sphere2 color purple
-bossbar set minecraft:sphere2 name [{text:"☼",color:"red"}]
+bossbar set minecraft:sphere2 name [{translate:att2.boss.name.sphere1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere3/spawn.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere3/spawn.mcfunction
@@ -13,4 +13,4 @@ bossbar add minecraft:sphere3 {"selector":"00000000-0000-022b-0000-00000000003b"
 bossbar set minecraft:sphere3 style notched_12
 bossbar set minecraft:sphere3 players @a
 bossbar set minecraft:sphere3 color purple
-bossbar set minecraft:sphere3 name [{text:"☼",color:"red"}]
+bossbar set minecraft:sphere3 name [{translate:att2.boss.name.sphere1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere4/spawn.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere4/spawn.mcfunction
@@ -13,4 +13,4 @@ bossbar add minecraft:sphere4 {"selector":"00000000-0000-022b-0000-00000000004b"
 bossbar set minecraft:sphere4 style notched_12
 bossbar set minecraft:sphere4 players @a
 bossbar set minecraft:sphere4 color purple
-bossbar set minecraft:sphere4 name [{text:"☼",color:"red"}]
+bossbar set minecraft:sphere4 name [{translate:att2.boss.name.sphere1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere5/spawn.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere5/spawn.mcfunction
@@ -13,4 +13,4 @@ bossbar add minecraft:sphere5 {"selector":"00000000-0000-022b-0000-00000000005b"
 bossbar set minecraft:sphere5 style notched_12
 bossbar set minecraft:sphere5 players @a
 bossbar set minecraft:sphere5 color purple
-bossbar set minecraft:sphere5 name [{text:"☼",color:"red"}]
+bossbar set minecraft:sphere5 name [{translate:att2.boss.name.sphere1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere6/spawn.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere6/spawn.mcfunction
@@ -13,4 +13,4 @@ bossbar add minecraft:sphere6 {"selector":"00000000-0000-022b-0000-00000000006b"
 bossbar set minecraft:sphere6 style notched_12
 bossbar set minecraft:sphere6 players @a
 bossbar set minecraft:sphere6 color purple
-bossbar set minecraft:sphere6 name [{text:"☼",color:"red"}]
+bossbar set minecraft:sphere6 name [{translate:att2.boss.name.sphere1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere7/spawn.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere7/spawn.mcfunction
@@ -13,4 +13,4 @@ bossbar add minecraft:sphere7 {"selector":"00000000-0000-022b-0000-00000000007b"
 bossbar set minecraft:sphere7 style notched_12
 bossbar set minecraft:sphere7 players @a
 bossbar set minecraft:sphere7 color purple
-bossbar set minecraft:sphere7 name [{text:"☼",color:"red"}]
+bossbar set minecraft:sphere7 name [{translate:att2.boss.name.sphere1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere8/spawn.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase1/sphere8/spawn.mcfunction
@@ -13,4 +13,4 @@ bossbar add minecraft:sphere8 {"selector":"00000000-0000-022b-0000-00000000008b"
 bossbar set minecraft:sphere8 style notched_12
 bossbar set minecraft:sphere8 players @a
 bossbar set minecraft:sphere8 color purple
-bossbar set minecraft:sphere8 name [{text:"☼",color:"red"}]
+bossbar set minecraft:sphere8 name [{translate:att2.boss.name.sphere1,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase2/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase2/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:sphere9 {"selector":"00000000-0000-022b-0000-00000000009b"
 bossbar set minecraft:sphere9 style notched_12
 bossbar set minecraft:sphere9 players @a
 bossbar set minecraft:sphere9 color purple
-bossbar set minecraft:sphere9 name [{text:"⬤",color:"red"}]
+bossbar set minecraft:sphere9 name [{translate:att2.boss.name.sphere9,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase3/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase3/init_bossbar.mcfunction
@@ -7,6 +7,6 @@ bossbar add minecraft:serile {"selector":"00000000-0000-022b-0000-00000000022b",
 bossbar set minecraft:serile style notched_12
 bossbar set minecraft:serile players @a
 bossbar set minecraft:serile color yellow
-bossbar set minecraft:serile name [{text:"Sérile",color:"yellow"}]
+bossbar set minecraft:serile name [{translate:att2.boss.name.serile,color:"yellow"}]
 
 team join yellow 00000000-0000-022b-0000-00000000022b

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase4/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase4/go.mcfunction
@@ -33,11 +33,11 @@ execute as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BO
 execute if entity @a[x=1543.0,y=25,z=1495.0,distance=..35,gamemode=adventure] store result bossbar minecraft:serile value run scoreboard players get 00000000-0000-022b-0000-00000000022b ENEMYHEALTH
 execute if entity @a[x=1543.0,y=25,z=1495.0,distance=..35,gamemode=adventure] store result bossbar minecraft:serile max run attribute 00000000-0000-022b-0000-00000000022b max_health get
 # Enable Bossbar storing Timer
-execute if entity @a[x=1543.0,y=25,z=1495.0,distance=..35,gamemode=adventure] store result bossbar minecraft:timer value run scoreboard players get 00000000-0000-022b-0000-00000000010b ENEMYHEALTH
-execute if entity @a[x=1543.0,y=25,z=1495.0,distance=..35,gamemode=adventure] store result bossbar minecraft:timer max run attribute 00000000-0000-022b-0000-00000000010b max_health get
+execute if entity @a[x=1543.0,y=25,z=1495.0,distance=..35,gamemode=adventure] store result bossbar minecraft:serile_timer value run scoreboard players get 00000000-0000-022b-0000-00000000010b ENEMYHEALTH
+execute if entity @a[x=1543.0,y=25,z=1495.0,distance=..35,gamemode=adventure] store result bossbar minecraft:serile_timer max run attribute 00000000-0000-022b-0000-00000000010b max_health get
 execute if entity @a[x=1543.0,y=25,z=1495.0,distance=..35,gamemode=adventure] store result score 00000000-0000-022b-0000-00000000010b SERILE run data get entity 00000000-0000-022b-0000-00000000010b Health 1
-bossbar set minecraft:timer visible false
-bossbar set minecraft:timer visible true
+bossbar set minecraft:serile_timer visible false
+bossbar set minecraft:serile_timer visible true
 
 # Process action
 function att2:gameplay/boss/serile/phase4/action

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase4/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase4/init_bossbar.mcfunction
@@ -3,9 +3,9 @@
 #Initialize bossbar Timer Serile								#
 #################################################################
 
-bossbar add minecraft:timer {"selector":"00000000-0000-022b-0000-00000000010b",color:"dark_red"}
-bossbar set minecraft:timer style notched_12
-bossbar set minecraft:timer players @a
-bossbar set minecraft:timer color yellow
-bossbar set minecraft:timer name "✠⁜☼⁜✠"
-execute store result bossbar minecraft:timer max run attribute 00000000-0000-022b-0000-00000000010b max_health get
+bossbar add minecraft:serile_timer {"selector":"00000000-0000-022b-0000-00000000010b",color:"dark_red"}
+bossbar set minecraft:serile_timer style notched_12
+bossbar set minecraft:serile_timer players @a
+bossbar set minecraft:serile_timer color yellow
+bossbar set minecraft:serile_timer name [{translate:att2.boss.name.serile_timer,color:"yellow"}]
+execute store result bossbar minecraft:serile_timer max run attribute 00000000-0000-022b-0000-00000000010b max_health get

--- a/adventquest_function/data/att2/function/gameplay/boss/serile/phase4/stop.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/serile/phase4/stop.mcfunction
@@ -8,7 +8,7 @@ stopsound @s
 tag @s remove NoAutoMusic
 scoreboard players set @s MUSIC_TIMER 20
 scoreboard players set @s MUSIC_BOSS 0
-bossbar set minecraft:timer visible false
-bossbar remove minecraft:timer
+bossbar set minecraft:serile_timer visible false
+bossbar remove minecraft:serile_timer
 bossbar set minecraft:serile visible false
 bossbar remove minecraft:serile

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/enter_arena.mcfunction
@@ -11,3 +11,6 @@ bossbar set minecraft:extratellur1 players @s
 bossbar set minecraft:extratellur2 players @s
 bossbar set minecraft:extratellur3 players @s
 bossbar set minecraft:extratellur4 players @s
+
+##show display_title
+function att2:gameplay/boss/silberland/extratellur/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/go.mcfunction
@@ -11,6 +11,9 @@
 particle minecraft:dust{color:[1,0,0],scale:1} -4571 54 -5982 3 3 0.1 0 15 normal
 particle minecraft:dust{color:[1,0,0],scale:1} -4571 58 -5950 5 7 0.1 0 50 normal
 
+##delay time
+execute if score extratellur_t BOSS_TIME matches ..-1 run return run scoreboard players add extratellur_t BOSS_TIME 1
+
 # Start the boss fight (summoning Extratellur)
 execute if score Extratellur SECRET_DUNGEON matches -1 if entity @a[x=-4559,y=65,z=-5981,dx=-25,dy=-16,dz=30,gamemode=adventure] run function att2:gameplay/boss/silberland/extratellur/start
 
@@ -37,7 +40,7 @@ execute if score Extratellur SECRET_DUNGEON matches 0.. unless entity @e[type=wa
 execute if score Extratellur SECRET_DUNGEON matches 0.. if entity @a[x=-4559,y=65,z=-5981,dx=-25,dy=-16,dz=30,gamemode=adventure] store result bossbar minecraft:extratellur4 max run attribute @e[tag=Extratellur,tag=EL4,limit=1] max_health get
 
 # Make challengers enters the arena
-execute as @a[x=-4565,y=50,z=-5983,dx=-12,dy=7,dz=0,gamemode=adventure] at @s unless entity @a[x=-4559,y=65,z=-5981,dx=-25,dy=-16,dz=30,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/silberland/extratellur/display_title
+#execute as @a[x=-4565,y=50,z=-5983,dx=-12,dy=7,dz=0,gamemode=adventure] at @s unless entity @a[x=-4559,y=65,z=-5981,dx=-25,dy=-16,dz=30,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/silberland/extratellur/display_title
 execute if score EnterArena SECRET_DUNGEON matches ..0 as @a[x=-4565,y=50,z=-5983,dx=-12,dy=7,dz=0,gamemode=adventure] run function att2:gameplay/boss/silberland/extratellur/enter_arena
 execute if score EnterArena SECRET_DUNGEON matches 1.. run scoreboard players remove EnterArena SECRET_DUNGEON 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/init_bossbar.mcfunction
@@ -7,22 +7,22 @@ bossbar add minecraft:extratellur1 {text:"extratellur1",color:"dark_red"}
 bossbar set minecraft:extratellur1 style notched_12
 bossbar set minecraft:extratellur1 players @a[x=-4559,y=65,z=-5981,dx=-25,dy=-16,dz=30,gamemode=adventure]
 bossbar set minecraft:extratellur1 color purple
-bossbar set minecraft:extratellur1 name [{text:"Extratellur",color:"red"}]
+bossbar set minecraft:extratellur1 name [{translate:att2.boss.name.extratellur,color:"red"}]
 
 bossbar add minecraft:extratellur2 {text:"extratellur2",color:"dark_red"}
 bossbar set minecraft:extratellur2 style notched_12
 bossbar set minecraft:extratellur2 players @a[x=-4559,y=65,z=-5981,dx=-25,dy=-16,dz=30,gamemode=adventure]
 bossbar set minecraft:extratellur2 color purple
-bossbar set minecraft:extratellur2 name [{text:"Extratellur",color:"red"}]
+bossbar set minecraft:extratellur2 name [{translate:att2.boss.name.extratellur,color:"red"}]
 
 bossbar add minecraft:extratellur3 {text:"extratellur3",color:"dark_red"}
 bossbar set minecraft:extratellur3 style notched_12
 bossbar set minecraft:extratellur3 players @a[x=-4559,y=65,z=-5981,dx=-25,dy=-16,dz=30,gamemode=adventure]
 bossbar set minecraft:extratellur3 color purple
-bossbar set minecraft:extratellur3 name [{text:"Extratellur",color:"red"}]
+bossbar set minecraft:extratellur3 name [{translate:att2.boss.name.extratellur,color:"red"}]
 
 bossbar add minecraft:extratellur4 {text:"extratellur4",color:"dark_red"}
 bossbar set minecraft:extratellur4 style notched_12
 bossbar set minecraft:extratellur4 players @a[x=-4559,y=65,z=-5981,dx=-25,dy=-16,dz=30,gamemode=adventure]
 bossbar set minecraft:extratellur4 color purple
-bossbar set minecraft:extratellur4 name [{text:"Extratellur",color:"red"}]
+bossbar set minecraft:extratellur4 name [{translate:att2.boss.name.extratellur,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset extratellur_t BOSS_TIME
+scoreboard players set extratellur_t BOSS_TIME -40
 scoreboard players reset extratellur_s BOSS_TIME
 scoreboard players reset extratellur_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/extratellur/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= extratellur_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/silberland/extratellur/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/silberland/extratellur/time/time_show
 
-scoreboard players reset extratellur_t BOSS_TIME
+scoreboard players set extratellur_t BOSS_TIME -40
 scoreboard players reset extratellur_s BOSS_TIME
 scoreboard players reset extratellur_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/enter_arena.mcfunction
@@ -10,3 +10,6 @@ scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:illusion1 players @s
 bossbar set minecraft:illusion2 players @s
 bossbar set minecraft:illusion3 players @s
+
+##show display_title
+function att2:gameplay/boss/silberland/illusions/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/go.mcfunction
@@ -11,6 +11,9 @@
 particle minecraft:dust{color:[1,0,0],scale:1} -4264 58 -5620 0.1 1 1 0 2 normal
 particle minecraft:dust{color:[1,0,0],scale:1} -4232 18 -5621 0.1 1 1 0 2 normal
 
+##delay time
+execute if score illusions_t BOSS_TIME matches ..-1 run return run scoreboard players add illusions_t BOSS_TIME 1
+
 # Music management
 execute if score Illusions SILBERLAND matches 0.. as @a[x=-4217,y=9,z=-5652,dx=-70,dy=33,dz=64,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Illusions SILBERLAND matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -30,7 +33,7 @@ execute if score Illusions SILBERLAND matches 0.. unless entity 00000000-0000-00
 execute if score Illusions SILBERLAND matches 0.. if entity @a[x=-4217,y=9,z=-5652,dx=-70,dy=33,dz=64,gamemode=adventure] store result bossbar minecraft:illusion3 max run attribute 00000000-0000-007c-0000-00000000007c max_health get
 
 # Make challengers enters the arena
-execute if score SQ33 SIDEQUEST matches 1..99 as @a[x=-4265,y=57,z=-5621,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-4217,y=9,z=-5652,dx=-70,dy=33,dz=64,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/silberland/illusions/display_title
+#execute if score SQ33 SIDEQUEST matches 1..99 as @a[x=-4265,y=57,z=-5621,dx=0,dy=2,dz=2,gamemode=adventure] at @s unless entity @a[x=-4217,y=9,z=-5652,dx=-70,dy=33,dz=64,gamemode=adventure,tag=!Dead] as @a[distance=..50] run function att2:gameplay/boss/silberland/illusions/display_title
 execute if score EnterArena SILBERLAND matches ..0 as @a[x=-4265,y=57,z=-5621,dx=0,dy=2,dz=2,gamemode=adventure] run function att2:gameplay/boss/silberland/illusions/enter_arena
 execute if score EnterArena SILBERLAND matches 1.. run scoreboard players remove EnterArena SILBERLAND 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/init_bossbar.mcfunction
@@ -7,16 +7,16 @@ bossbar add minecraft:illusion1 {"selector":"00000000-0000-005c-0000-00000000005
 bossbar set minecraft:illusion1 style notched_12
 bossbar set minecraft:illusion1 players @a[x=-4217,y=9,z=-5652,dx=-70,dy=33,dz=64,gamemode=adventure]
 bossbar set minecraft:illusion1 color purple
-bossbar set minecraft:illusion1 name [{text:"Illusion",color:"red"}]
+bossbar set minecraft:illusion1 name [{translate:att2.boss.name.illusion,color:"red"}]
 
 bossbar add minecraft:illusion2 {"selector":"00000000-0000-006c-0000-00000000006c",color:"dark_red"}
 bossbar set minecraft:illusion2 style notched_12
 bossbar set minecraft:illusion2 players @a[x=-4217,y=9,z=-5652,dx=-70,dy=33,dz=64,gamemode=adventure]
 bossbar set minecraft:illusion2 color purple
-bossbar set minecraft:illusion2 name [{text:"Illusion",color:"red"}]
+bossbar set minecraft:illusion2 name [{translate:att2.boss.name.illusion,color:"red"}]
 
 bossbar add minecraft:illusion3 {"selector":"00000000-0000-007c-0000-00000000007c",color:"dark_red"}
 bossbar set minecraft:illusion3 style notched_12
 bossbar set minecraft:illusion3 players @a[x=-4217,y=9,z=-5652,dx=-70,dy=33,dz=64,gamemode=adventure]
 bossbar set minecraft:illusion3 color purple
-bossbar set minecraft:illusion3 name [{text:"Illusion",color:"red"}]
+bossbar set minecraft:illusion3 name [{translate:att2.boss.name.illusion,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset illusions_t BOSS_TIME
+scoreboard players set illusions_t BOSS_TIME -40
 scoreboard players reset illusions_s BOSS_TIME
 scoreboard players reset illusions_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/silberland/illusions/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= illusions_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/silberland/illusions/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/silberland/illusions/time/time_show
 
-scoreboard players reset illusions_t BOSS_TIME
+scoreboard players set illusions_t BOSS_TIME -40
 scoreboard players reset illusions_s BOSS_TIME
 scoreboard players reset illusions_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:blobby players @s
+
+##show display_title
+function att2:gameplay/boss/worlest/blobby/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/go.mcfunction
@@ -11,6 +11,9 @@
 execute if score Blobby SQ54 matches -2.. run particle minecraft:dust{color:[1,0,0],scale:1} -5355 74 -4999 2 2 0 1 4 normal
 execute if score Blobby SQ54 matches -2.. run particle minecraft:dust{color:[1,0,0],scale:1} -5356 42 -4922 2 2 0 1 4 normal
 
+##delay time
+execute if score blobby_t BOSS_TIME matches ..-1 run return run scoreboard players add blobby_t BOSS_TIME 1
+
 # Music management
 execute if score Blobby SQ54 matches 0.. as @a[x=-5392,y=23,z=-4999,dx=77,dy=100,dz=77,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_sideboss
 execute if score Blobby SQ54 matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -20,7 +23,7 @@ execute if score Blobby SQ54 matches 0.. if entity @a[x=-5392,y=23,z=-4999,dx=77
 execute if score Blobby SQ54 matches 0.. if entity @a[x=-5392,y=23,z=-4999,dx=77,dy=100,dz=77,gamemode=adventure] store result bossbar minecraft:blobby max run attribute 00000000-0000-022c-0000-00000000022c max_health get
 
 # Make challengers enters the arena
-execute if score SQ54 SIDEQUEST matches 1..99 as @a[x=-5358,y=71,z=-5000,dx=6,dy=5,dz=0,gamemode=adventure] at @s unless entity @a[x=-5392,y=23,z=-4999,dx=77,dy=100,dz=77,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/worlest/blobby/display_title
+#execute if score SQ54 SIDEQUEST matches 1..99 as @a[x=-5358,y=71,z=-5000,dx=6,dy=5,dz=0,gamemode=adventure] at @s unless entity @a[x=-5392,y=23,z=-4999,dx=77,dy=100,dz=77,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/worlest/blobby/display_title
 execute if score EnterArena SQ54 matches ..0 as @a[x=-5358,y=71,z=-5000,dx=6,dy=5,dz=0,gamemode=adventure] run function att2:gameplay/boss/worlest/blobby/enter_arena
 execute if score EnterArena SQ54 matches 1.. run scoreboard players remove EnterArena SQ54 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:blobby {"selector":"00000000-0000-022c-0000-00000000022c",
 bossbar set minecraft:blobby style notched_12
 bossbar set minecraft:blobby players @a[x=-5392,y=23,z=-4999,dx=77,dy=100,dz=77,gamemode=adventure]
 bossbar set minecraft:blobby color purple
-bossbar set minecraft:blobby name [{text:"Blobby",color:"red"}]
+bossbar set minecraft:blobby name [{translate:att2.boss.name.blobby,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset blobby_t BOSS_TIME
+scoreboard players set blobby_t BOSS_TIME -40
 scoreboard players reset blobby_s BOSS_TIME
 scoreboard players reset blobby_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/blobby/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= blobby_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/worlest/blobby/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/worlest/blobby/time/time_show
 
-scoreboard players reset blobby_t BOSS_TIME
+scoreboard players set blobby_t BOSS_TIME -40
 scoreboard players reset blobby_s BOSS_TIME
 scoreboard players reset blobby_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/enter_arena.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/enter_arena.mcfunction
@@ -8,3 +8,6 @@ stopsound @s
 tag @s add NoAutoMusic
 scoreboard players set @s MUSIC_BOSS 0
 bossbar set minecraft:felroth players @s
+say 我是?
+##show display_title
+function att2:gameplay/boss/worlest/felroth/display_title

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/go.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/go.mcfunction
@@ -11,6 +11,9 @@
 particle minecraft:dust{color:[1,0,0],scale:1} -4636 58 -5505 1.5 1.5 0 0 5 force
 particle minecraft:dust{color:[1,0,0],scale:1} -4636 59 -5537 1.5 1.5 0 0 5 force
 
+##delay time
+execute if score felroth_t BOSS_TIME matches ..-1 run return run scoreboard players add felroth_t BOSS_TIME 1
+
 # Music management
 execute if score Felroth WORLEST matches 0.. as @a[x=-4652,y=56,z=-5537,dx=32,dy=8,dz=32,scores={MUSIC_BOSS=0}] at @s run function att2:gameplay/boss/music_boss
 execute if score Felroth WORLEST matches 0.. as @a[scores={MUSIC_BOSS=1..}] run scoreboard players remove @s MUSIC_BOSS 1
@@ -20,7 +23,7 @@ execute if score Felroth WORLEST matches 0.. if entity @a[x=-4652,y=56,z=-5537,d
 execute if score Felroth WORLEST matches 0.. if entity @a[x=-4652,y=56,z=-5537,dx=32,dy=8,dz=32,gamemode=adventure] store result bossbar minecraft:felroth value run scoreboard players get 00000000-0000-001b-0000-00000000001b ENEMYHEALTH
 
 # Make challengers enters the arena
-execute if score Mainquest SIDEQUEST matches 14 as @a[x=-4635,y=57,z=-5538,dx=-2,dy=3,dz=0,gamemode=adventure] at @s unless entity @a[x=-4652,y=56,z=-5537,dx=32,dy=8,dz=32,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/worlest/felroth/display_title
+#execute if score Mainquest SIDEQUEST matches 14 as @a[x=-4635,y=57,z=-5538,dx=-2,dy=3,dz=0,gamemode=adventure] at @s unless entity @a[x=-4652,y=56,z=-5537,dx=32,dy=8,dz=32,gamemode=adventure,tag=!Dead] as @a[distance=..30] run function att2:gameplay/boss/worlest/felroth/display_title
 execute if score EnterArena WORLEST matches ..0 as @a[x=-4635,y=57,z=-5538,dx=-2,dy=3,dz=0,gamemode=adventure] run function att2:gameplay/boss/worlest/felroth/enter_arena
 execute if score EnterArena WORLEST matches 1.. run scoreboard players remove EnterArena WORLEST 1
 

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/init_bossbar.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/init_bossbar.mcfunction
@@ -7,4 +7,4 @@ bossbar add minecraft:felroth {"selector":"00000000-0000-001b-0000-00000000001b"
 bossbar set minecraft:felroth style notched_12
 bossbar set minecraft:felroth players @a[x=-4652,y=56,z=-5537,dx=32,dy=8,dz=32,gamemode=adventure]
 bossbar set minecraft:felroth color purple
-bossbar set minecraft:felroth name [{text:"Felroth",color:"red"}]
+bossbar set minecraft:felroth name [{translate:att2.boss.name.felroth,color:"red"}]

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/time/fail.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/time/fail.mcfunction
@@ -4,6 +4,6 @@
 #########################################################
 
 ##fail
-scoreboard players reset felroth_t BOSS_TIME
+scoreboard players set felroth_t BOSS_TIME -40
 scoreboard players reset felroth_s BOSS_TIME
 scoreboard players reset felroth_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/time/time_over.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/boss/worlest/felroth/time/time_over.mcfunction
@@ -24,6 +24,6 @@ scoreboard players operation test_t BOSS_TIME -= felroth_rt BOSS_TIME
 execute if score newrecord BOSS_TIME matches 1 unless score test_t BOSS_TIME matches 0.. as @a at @s run function att2:gameplay/boss/worlest/felroth/time/time_record
 execute if score newrecord BOSS_TIME matches 1 if score test_t BOSS_TIME matches 1.. as @a at @s run function att2:gameplay/boss/worlest/felroth/time/time_show
 
-scoreboard players reset felroth_t BOSS_TIME
+scoreboard players set felroth_t BOSS_TIME -40
 scoreboard players reset felroth_s BOSS_TIME
 scoreboard players reset felroth_m BOSS_TIME

--- a/adventquest_function/data/att2/function/gameplay/enveffect/initialize.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/initialize.mcfunction
@@ -12,3 +12,4 @@ function att2:gameplay/enveffect/fairy/initialize
 function att2:gameplay/enveffect/mobs_invasion/initialize
 function att2:gameplay/enveffect/mimic/initialize
 function att2:gameplay/enveffect/elite/initialize
+function att2:gameplay/enveffect/pickable_item/initialize

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/initialize.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/initialize.mcfunction
@@ -1,0 +1,6 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+scoreboard objectives add PickableItem dummy

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/particle.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/particle.mcfunction
@@ -1,0 +1,15 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+scoreboard players operation #Overlay CAL = @s PickableItem
+scoreboard players operation #Overlay CAL /= 100 CAL
+##particle
+
+##dirt
+execute if score #Overlay CAL matches 1 run return run particle minecraft:block{block_state:"minecraft:dirt"} ~ ~ ~ 0.2 0.2 0.2 0.1 10
+##grass
+execute if score #Overlay CAL matches 2 run return run particle minecraft:block{block_state:"minecraft:moss_block"} ~ ~ ~ 0.2 0.2 0.2 0.1 10
+##stone
+execute if score #Overlay CAL matches 3 run return run particle minecraft:block{block_state:"minecraft:stone"} ~ ~ ~ 0.2 0.2 0.2 0.1 10

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/reward/chronoton.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/reward/chronoton.mcfunction
@@ -1,0 +1,9 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##loot
+loot spawn ~ ~ ~ loot att2:entities/boss/coins_rewards
+loot spawn ~ ~ ~ loot att2:item_data/chronoton/small
+loot spawn ~ ~ ~ loot att2:item_data/chronoton/big

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/reward/esc.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/reward/esc.mcfunction
@@ -1,0 +1,8 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##loot
+loot spawn ~ ~ ~ loot att2:entities/boss/esc_rewards
+loot spawn ~ ~ ~ loot att2:item_data/chronoton/esc

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/reward/rune.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/reward/rune.mcfunction
@@ -1,0 +1,8 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##loot
+loot spawn ~ ~ ~ loot att2:entities/invasion_runes_1
+loot spawn ~ ~ ~ loot att2:entities/invasion_runes_1

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/sound.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/sound.mcfunction
@@ -1,0 +1,23 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+scoreboard players operation #Overlay CAL = @s PickableItem
+scoreboard players operation #Overlay CAL /= 100 CAL
+##particle
+
+##dirt
+execute if score #Overlay CAL matches 1 run return run playsound minecraft:block.gravel.break block @a ~ ~ ~ 1 1
+##grass
+execute if score #Overlay CAL matches 2 run return run playsound minecraft:block.grass.break block @a ~ ~ ~ 1 1
+##stone
+execute if score #Overlay CAL matches 3 run return run playsound minecraft:block.stone.break block @a ~ ~ ~ 1 1
+##ice
+execute if score #Overlay CAL matches 4 run return run playsound minecraft:block.glass.break block @a ~ ~ ~ 1 1
+##angband_stone
+execute if score #Overlay CAL matches 5 run return run playsound minecraft:block.stone.break block @a ~ ~ ~ 1 1
+##billgart_stone
+execute if score #Overlay CAL matches 6 run return run playsound minecraft:block.stone.break block @a ~ ~ ~ 1 1
+##ouranos_stone
+execute if score #Overlay CAL matches 7 run return run playsound minecraft:block.stone.break block @a ~ ~ ~ 1 1

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/auto_summon.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/auto_summon.mcfunction
@@ -1,0 +1,12 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##get data
+execute store result score #Rotation PickableItem run data get entity @s data.rotation
+execute store result score #Overlay PickableItem run data get entity @s data.overlay
+execute store result score #Item PickableItem run data get entity @s data.item
+
+##summon
+execute align xyz run function att2:gameplay/enveffect/pickable_item/summon/base

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/base.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/base.mcfunction
@@ -1,0 +1,38 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+#kill @e[tag=PickableItem]
+##summon interaction+item_display
+summon interaction ~ ~ ~ {Tags:["PickableItem","General","New"],Rotation:[0,90],width:1,height:0.1,response:true,data:{general_attack_function:"function att2:gameplay/enveffect/pickable_item/trigger/left",general_interact_function:"function att2:gameplay/enveffect/pickable_item/trigger/right"},Passengers:[{Tags:["PickableItem","Item","New"],id:"item_display",Rotation:[0,90],view_range:0.5,item:{id:diamond,components:{item_model:"nothing"}},transformation:{scale:[1.0f,1.0f,1.0f],translation:[0.0f,0.0f,0.1f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,0.0f,0.0f,1.0f]}},{Tags:["PickableItem","Overlay","New"],id:"item_display",Rotation:[0,90],view_range:0.5,item:{id:diamond,components:{item_model:"nothing",custom_model_data:{floats:[1]}}},transformation:{scale:[1.0f,1.0f,1.0f],translation:[0.0f,0.0f,0.1f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,0.0f,0.0f,1.0f]}}]}
+
+##set overlay
+function att2:gameplay/enveffect/pickable_item/summon/overlay
+
+##set type
+function att2:gameplay/enveffect/pickable_item/summon/type
+
+##sync score
+scoreboard players operation @n[distance=..10,type=interaction,tag=New,tag=PickableItem] PickableItem = #Item PickableItem
+scoreboard players operation #Overlay CAL = #Overlay PickableItem
+scoreboard players operation #Overlay CAL *= 100 CAL
+scoreboard players operation @n[distance=..10,type=interaction,tag=New,tag=PickableItem] PickableItem += #Overlay CAL
+
+##set rotation
+
+##up
+execute if score #Rotation PickableItem matches 1 run function att2:gameplay/enveffect/pickable_item/summon/facing/up
+##down
+execute if score #Rotation PickableItem matches 2 run function att2:gameplay/enveffect/pickable_item/summon/facing/down
+##south
+execute if score #Rotation PickableItem matches 3 run function att2:gameplay/enveffect/pickable_item/summon/facing/south
+##north
+execute if score #Rotation PickableItem matches 4 run function att2:gameplay/enveffect/pickable_item/summon/facing/north
+##east
+execute if score #Rotation PickableItem matches 5 run function att2:gameplay/enveffect/pickable_item/summon/facing/east
+##north
+execute if score #Rotation PickableItem matches 6 run function att2:gameplay/enveffect/pickable_item/summon/facing/west
+
+##remove tag
+tag @e[distance=..10,type=#minecraft:display_entity,tag=New,tag=PickableItem] remove New

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/base.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/base.mcfunction
@@ -31,8 +31,10 @@ execute if score #Rotation PickableItem matches 3 run function att2:gameplay/env
 execute if score #Rotation PickableItem matches 4 run function att2:gameplay/enveffect/pickable_item/summon/facing/north
 ##east
 execute if score #Rotation PickableItem matches 5 run function att2:gameplay/enveffect/pickable_item/summon/facing/east
-##north
+##west
 execute if score #Rotation PickableItem matches 6 run function att2:gameplay/enveffect/pickable_item/summon/facing/west
 
+#clear
+execute at @n[distance=..10,type=interaction,tag=New,tag=PickableItem] as @e[distance=..1,type=minecraft:interaction,tag=!New,tag=PickableItem] run function att2:gameplay/enveffect/pickable_item/trigger/clear
 ##remove tag
 tag @e[distance=..10,type=#minecraft:display_entity,tag=New,tag=PickableItem] remove New

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/chronoton.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/chronoton.mcfunction
@@ -1,0 +1,8 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##
+scoreboard players set #Item PickableItem 1
+function att2:gameplay/enveffect/pickable_item/summon/base

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/esc.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/esc.mcfunction
@@ -1,0 +1,8 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##
+scoreboard players set #Item PickableItem 2
+function att2:gameplay/enveffect/pickable_item/summon/base

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/down.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/down.mcfunction
@@ -1,0 +1,13 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##rotate
+execute as @e[distance=..10,type=#minecraft:display_entity,tag=New,tag=PickableItem] run rotate @s 0 -90
+##transformation
+execute as @e[distance=..10,type=minecraft:item_display,tag=New,tag=PickableItem] run data modify entity @s transformation set value {scale:[1.0f,1.0f,1.0f],translation:[0.0f,0.0f,-0.1f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,0.0f,0.0f,1.0f]}
+##width/height
+data merge entity @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] {height:0.1,width:1}
+##position
+execute align xyz positioned ~0.5 ~-0.101 ~0.5 as @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] run tp @s ~ ~ ~ 

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/east.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/east.mcfunction
@@ -1,0 +1,13 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##rotate
+execute as @e[distance=..10,type=#minecraft:display_entity,tag=New,tag=PickableItem] run rotate @s 90 0
+##transformation
+execute as @e[distance=..10,type=minecraft:item_display,tag=New,tag=PickableItem] run data modify entity @s transformation set value {scale:[1.0f,1.0f,1.0f],translation:[0.0f,-0.5f,-0.5f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,0.0f,0.0f,1.0f]}
+##width/height
+data merge entity @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] {height:1,width:1}
+##position
+execute align xyz positioned ~0.540 ~ ~0.5 as @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] run tp @s ~ ~ ~ 

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/north.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/north.mcfunction
@@ -1,0 +1,13 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##rotate
+execute as @e[distance=..10,type=#minecraft:display_entity,tag=New,tag=PickableItem] run rotate @s 0 0
+##transformation
+execute as @e[distance=..10,type=minecraft:item_display,tag=New,tag=PickableItem] run data modify entity @s transformation set value {scale:[1.0f,1.0f,1.0f],translation:[0.0f,-0.5f,-0.5f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,0.0f,0.0f,1.0f]}
+##width/height
+data merge entity @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] {height:1,width:1}
+##position
+execute align xyz positioned ~0.5 ~ ~0.460 as @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] run tp @s ~ ~ ~ 

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/south.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/south.mcfunction
@@ -1,0 +1,13 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##rotate
+execute as @e[distance=..10,type=#minecraft:display_entity,tag=New,tag=PickableItem] run rotate @s 180 0
+##transformation
+execute as @e[distance=..10,type=minecraft:item_display,tag=New,tag=PickableItem] run data modify entity @s transformation set value {scale:[1.0f,1.0f,1.0f],translation:[0.0f,-0.5f,-0.5f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,0.0f,0.0f,1.0f]}
+##width/height
+data merge entity @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] {height:1,width:1}
+##position
+execute align xyz positioned ~0.5 ~ ~0.540 as @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] run tp @s ~ ~ ~ 

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/up.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/up.mcfunction
@@ -1,0 +1,13 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##rotate
+execute as @e[distance=..10,type=#minecraft:display_entity,tag=New,tag=PickableItem] run rotate @s 0 90
+##transformation
+execute as @e[distance=..10,type=minecraft:item_display,tag=New,tag=PickableItem] run data modify entity @s transformation set value {scale:[1.0f,1.0f,1.0f],translation:[0.0f,0.0f,0.1f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,0.0f,0.0f,1.0f]}
+##width/height
+data merge entity @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] {height:0.1,width:1}
+##position
+execute align xyz positioned ~0.5 ~1 ~0.5 as @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] run tp @s ~ ~ ~ 

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/west.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/facing/west.mcfunction
@@ -1,0 +1,13 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##rotate
+execute as @e[distance=..10,type=#minecraft:display_entity,tag=New,tag=PickableItem] run rotate @s -90 0
+##transformation
+execute as @e[distance=..10,type=minecraft:item_display,tag=New,tag=PickableItem] run data modify entity @s transformation set value {scale:[1.0f,1.0f,1.0f],translation:[0.0f,-0.5f,-0.5f],right_rotation:[0.0f,0.0f,0.0f,1.0f],left_rotation:[0.0f,0.0f,0.0f,1.0f]}
+##width/height
+data merge entity @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] {height:1,width:1}
+##position
+execute align xyz positioned ~0.460 ~ ~0.5 as @n[distance=..10,type=minecraft:interaction,tag=New,tag=PickableItem] run tp @s ~ ~ ~ 

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/maco_test_summon.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/maco_test_summon.mcfunction
@@ -1,0 +1,12 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##get data
+$scoreboard players set #Rotation PickableItem $(rotation)
+$scoreboard players set #Overlay PickableItem $(overlay)
+$scoreboard players set #Item PickableItem $(item)
+
+##summon
+execute align xyz run function att2:gameplay/enveffect/pickable_item/summon/base

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/overlay.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/overlay.mcfunction
@@ -1,0 +1,19 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##dirt
+execute if score #Overlay PickableItem matches 1 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Overlay] item.components."minecraft:item_model" set value "pickable_item/overlay/dirt"
+##grass
+execute if score #Overlay PickableItem matches 2 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Overlay] item.components."minecraft:item_model" set value "pickable_item/overlay/grass"
+##stone
+execute if score #Overlay PickableItem matches 3 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Overlay] item.components."minecraft:item_model" set value "pickable_item/overlay/stone"
+##ice
+execute if score #Overlay PickableItem matches 4 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Overlay] item.components."minecraft:item_model" set value "pickable_item/overlay/ice"
+##angband_stone
+execute if score #Overlay PickableItem matches 5 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Overlay] item.components."minecraft:item_model" set value "pickable_item/overlay/angband_stone"
+##billgart_stone
+execute if score #Overlay PickableItem matches 6 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Overlay] item.components."minecraft:item_model" set value "pickable_item/overlay/billgart_stone"
+##ouranos_stone
+execute if score #Overlay PickableItem matches 7 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Overlay] item.components."minecraft:item_model" set value "pickable_item/overlay/ouranos_stone"

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/rune.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/rune.mcfunction
@@ -1,0 +1,8 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##
+scoreboard players set #Item PickableItem 3
+function att2:gameplay/enveffect/pickable_item/summon/base

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/type.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/summon/type.mcfunction
@@ -1,0 +1,11 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##Chronoton
+execute if score #Item PickableItem matches 1 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Item] item.components."minecraft:item_model" set value "pickable_item/chronoton"
+##ESC
+execute if score #Item PickableItem matches 2 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Item] item.components."minecraft:item_model" set value "pickable_item/esc"
+##Rune
+execute if score #Item PickableItem matches 3 run return run data modify entity @n[distance=..10,type=item_display,tag=New,tag=PickableItem,tag=Item] item.components."minecraft:item_model" set value "pickable_item/rune"

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/animation.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/animation.mcfunction
@@ -1,0 +1,14 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##get custom_model_data
+execute store result score #count CAL run data get entity @s item.components."minecraft:custom_model_data".floats[0]
+##add score
+scoreboard players add #count CAL 1
+##clear
+execute if score #count CAL matches 5.. on vehicle as @s[type=interaction,tag=PickableItem] run function att2:gameplay/enveffect/pickable_item/trigger/reward
+scoreboard players operation #count CAL < 4 CAL
+##return
+execute store result entity @s item.components."minecraft:custom_model_data".floats[0] int 1 run scoreboard players get #count CAL

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/clear.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/clear.mcfunction
@@ -1,0 +1,10 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##sound
+playsound minecraft:entity.horse.saddle ambient @a ~ ~ ~ 1 0.5
+##clear entity
+execute on passengers run kill @s[tag=PickableItem]
+kill @s[tag=PickableItem]

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/effect.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/effect.mcfunction
@@ -1,0 +1,12 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##sound
+function att2:gameplay/enveffect/pickable_item/sound
+##particle
+function att2:gameplay/enveffect/pickable_item/particle
+
+#scoreboard player
+execute on passengers as @s[tag=Overlay] run function att2:gameplay/enveffect/pickable_item/trigger/animation

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/reward.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/reward.mcfunction
@@ -1,0 +1,20 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+##get item score
+scoreboard players operation #Item CAL = @s PickableItem
+scoreboard players operation #Item CAL %= 100 CAL
+
+##loot
+
+##chronoton
+execute if score #Item CAL matches 1 run function att2:gameplay/enveffect/pickable_item/reward/chronoton
+##esc
+execute if score #Item CAL matches 2 run function att2:gameplay/enveffect/pickable_item/reward/esc
+##rune
+execute if score #Item CAL matches 3 run function att2:gameplay/enveffect/pickable_item/reward/rune
+
+##clear
+function att2:gameplay/enveffect/pickable_item/trigger/clear

--- a/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/right.mcfunction
+++ b/adventquest_function/data/att2/function/gameplay/enveffect/pickable_item/trigger/right.mcfunction
@@ -1,0 +1,7 @@
+#################################################################
+#Made by Adventquest											#
+#Initialize enveffect											#
+#################################################################
+
+#scoreboard player
+execute as @e[distance=..10,type=interaction,tag=PickableItem,tag=TempSelect] at @s run function att2:gameplay/enveffect/pickable_item/trigger/effect

--- a/adventquest_function/data/att2/tags/item/armor/chest.json
+++ b/adventquest_function/data/att2/tags/item/armor/chest.json
@@ -1,0 +1,11 @@
+{
+  "values": [
+    "minecraft:chainmail_chestplate",
+    "minecraft:copper_chestplate",
+    "minecraft:diamond_chestplate",
+    "minecraft:golden_chestplate",
+    "minecraft:iron_chestplate",
+    "minecraft:leather_chestplate",
+    "minecraft:netherite_chestplate"
+  ]
+}

--- a/adventquest_function/data/att2/tags/item/armor/feet.json
+++ b/adventquest_function/data/att2/tags/item/armor/feet.json
@@ -1,0 +1,11 @@
+{
+  "values": [
+    "minecraft:chainmail_boots",
+    "minecraft:copper_boots",
+    "minecraft:diamond_boots",
+    "minecraft:golden_boots",
+    "minecraft:iron_boots",
+    "minecraft:leather_boots",
+    "minecraft:netherite_boots"
+  ]
+}

--- a/adventquest_function/data/att2/tags/item/armor/head.json
+++ b/adventquest_function/data/att2/tags/item/armor/head.json
@@ -1,0 +1,11 @@
+{
+  "values": [
+    "minecraft:chainmail_helmet",
+    "minecraft:copper_helmet",
+    "minecraft:diamond_helmet",
+    "minecraft:golden_helmet",
+    "minecraft:iron_helmet",
+    "minecraft:leather_helmet",
+    "minecraft:netherite_helmet"
+  ]
+}

--- a/adventquest_function/data/att2/tags/item/armor/legs.json
+++ b/adventquest_function/data/att2/tags/item/armor/legs.json
@@ -1,0 +1,11 @@
+{
+  "values": [
+    "minecraft:chainmail_leggings",
+    "minecraft:copper_leggings",
+    "minecraft:diamond_leggings",
+    "minecraft:golden_leggings",
+    "minecraft:iron_leggings",
+    "minecraft:leather_leggings",
+    "minecraft:netherite_leggings"
+  ]
+}

--- a/adventquest_function/data/att2/tags/item/weapon/all.json
+++ b/adventquest_function/data/att2/tags/item/weapon/all.json
@@ -1,0 +1,11 @@
+{
+  "values": [
+    "#att2:weapon/copper",
+    "#att2:weapon/diamond",
+    "#att2:weapon/golden",
+    "#att2:weapon/iron",
+    "#att2:weapon/netherite",
+    "#att2:weapon/stone",
+    "#att2:weapon/wooden"
+  ]
+}

--- a/adventquest_function/data/att2_enchantment/enchantment/sword_of_jab.json
+++ b/adventquest_function/data/att2_enchantment/enchantment/sword_of_jab.json
@@ -1,0 +1,23 @@
+{
+    "anvil_cost": 7,
+    "description": {
+        "translate": "enchantment.att2.sword_of_jab"
+    },
+    "max_cost": {
+        "base": 7,
+        "per_level_above_first": 7
+    },
+    "max_level": 1,
+    "min_cost": {
+        "base": 7,
+        "per_level_above_first": 7
+    },
+    "slots": [
+        "mainhand"
+    ],
+    "supported_items": "#minecraft:swords",
+    "exclusive_set": [
+        "att2_enchantment:sword_of_stone"
+    ],
+    "weight": 1
+}

--- a/adventquest_function/data/att2_enchantment/enchantment/sword_of_stone.json
+++ b/adventquest_function/data/att2_enchantment/enchantment/sword_of_stone.json
@@ -1,0 +1,63 @@
+{
+    "anvil_cost": 7,
+    "description": {
+        "translate": "enchantment.att2.sword_of_stone"
+    },
+    "max_cost": {
+        "base": 7,
+        "per_level_above_first": 7
+    },
+    "max_level": 5,
+    "min_cost": {
+        "base": 7,
+        "per_level_above_first": 7
+    },
+    "slots": [
+        "mainhand"
+    ],
+    "supported_items": "#minecraft:swords",
+    "exclusive_set": [
+        "att2_enchantment:sword_of_jab",
+        "att2_enchantment:sscombo",
+        "att2_enchantment:greatsword"
+    ],
+    "weight": 1,
+    "effects": {
+        "post_attack": [
+            {
+                "affected": "victim",
+                "enchanted": "attacker",
+                "requirements": [
+                    {
+                        "condition": "entity_properties",
+                        "entity": "this",
+                        "predicate": {
+                            "team": "hostile"
+                        }
+                    }
+                ],
+                "effect": {
+                    "type": "run_function",
+                    "function": "att2:gameplay/enchantment/sword_of_stone/kill_detection"
+                }
+            },
+            {
+                "affected": "attacker",
+                "enchanted": "attacker",
+                "requirements": [
+                    {
+                        "condition": "entity_properties",
+                        "entity": "this",
+                        "predicate": {
+                            "team": "hostile"
+                        }
+                    }
+                ],
+                "effect": {
+                    "type": "run_function",
+                    "function": "att2:gameplay/enchantment/sword_of_stone/kill_trigger"
+                }
+            }
+        ]
+    }
+}

--- a/adventquest_function/data/minecraft/tags/item/potions.json
+++ b/adventquest_function/data/minecraft/tags/item/potions.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "minecraft:potion",
+    "minecraft:splash_potion",
+    "minecraft:lingering_potion"
+  ]
+}

--- a/adventquest_item_modifier/data/att2/item_modifier/count/maco.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/count/maco.json
@@ -1,0 +1,12 @@
+{
+  "function": "set_count",
+  "add": true,
+  "count": {
+    "type": "score",
+    "target": {
+      "type": "fixed",
+      "name": "#count"
+    },
+    "score": "CAL"
+  }
+}

--- a/adventquest_item_modifier/data/att2/item_modifier/dahal/update_launch_data.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/dahal/update_launch_data.json
@@ -1,0 +1,67 @@
+[
+  {
+    "function": "set_custom_model_data",
+    "floats": {
+      "mode": "replace_all",
+      "values": [
+        {
+          "type": "score",
+          "score": "CAL",
+          "target": {
+            "type": "fixed",
+            "name": "#cooldown_percent"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "conditions": [
+      {
+        "condition": "value_check",
+        "value": {
+          "type": "score",
+          "score": "CAL",
+          "target": {
+            "type": "fixed",
+            "name": "#cooldown_percent"
+          }
+        },
+        "range": {
+          "min": 1
+        }
+      }
+    ],
+    "function": "set_components",
+    "components": {
+      "!minecraft:consumable": {}
+    }
+  },
+  {
+    "conditions": [
+      {
+        "condition": "value_check",
+        "value": {
+          "type": "score",
+          "score": "CAL",
+          "target": {
+            "type": "fixed",
+            "name": "#cooldown_percent"
+          }
+        },
+        "range": 0
+      }
+    ],
+    "function": "set_components",
+    "components": {
+      "minecraft:consumable": {
+        "animation": "trident",
+        "consume_seconds": 0.05,
+        "has_consume_particles": false,
+        "sound": {
+          "sound_id": ""
+        }
+      }
+    }
+  }
+]

--- a/adventquest_item_modifier/data/att2/item_modifier/dahal/update_launch_data_spell_bundle copy.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/dahal/update_launch_data_spell_bundle copy.json
@@ -1,0 +1,930 @@
+{
+  "function": "modify_contents",
+  "component": "bundle_contents",
+  "modifier": [
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 1
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/1"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 2
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/2"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 3
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/3"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 4
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/4"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 5
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/5"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 6
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/6"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 7
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/7"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 8
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/8"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 9
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/9"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 10
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/10"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 11
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/11"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 21
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/21"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 22
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/22"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 23
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/23"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 24
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/24"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 25
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/25"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 26
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/26"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 27
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/27"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 28
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/28"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 29
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/29"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 30
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/30"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 31
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/31"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 32
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/32"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 33
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/33"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 34
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/34"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 35
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/35"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 40
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/40"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 41
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/41"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 42
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/42"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 43
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/43"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 44
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/44"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 45
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/45"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 46
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/46"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    }
+  ]
+}

--- a/adventquest_item_modifier/data/att2/item_modifier/dahal/update_launch_data_spell_bundle.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/dahal/update_launch_data_spell_bundle.json
@@ -1,0 +1,929 @@
+{
+  "function": "sequence",
+  "functions": [
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 1
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/1"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 2
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/2"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 3
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/3"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 4
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/4"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 5
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/5"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 6
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/6"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 7
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/7"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 8
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/8"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 9
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/9"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 10
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/10"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 11
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/11"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 21
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/21"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 22
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/22"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 23
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/23"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 24
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/24"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 25
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/25"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 26
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/26"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 27
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/27"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 28
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/28"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 29
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/29"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 30
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/30"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 31
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/31"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 32
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/32"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 33
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/33"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 34
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/34"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 35
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/35"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 40
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/40"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 41
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/41"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 42
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/42"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 43
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/43"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 44
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/44"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 45
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/45"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    },
+    {
+      "conditions": [
+        {
+          "condition": "value_check",
+          "value": {
+            "type": "score",
+            "score": "CAL",
+            "target": {
+              "type": "fixed",
+              "name": "#id"
+            }
+          },
+          "range": 46
+        }
+      ],
+      "function": "filtered",
+      "item_filter": {
+        "components": {
+          "item_model": "spell/46"
+        }
+      },
+      "on_pass": [
+        {
+          "function": "reference",
+          "name": "att2:dahal/update_launch_data"
+        }
+      ]
+    }
+  ]
+}

--- a/adventquest_item_modifier/data/att2/item_modifier/durability/random.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/durability/random.json
@@ -1,0 +1,9 @@
+{
+  "function": "set_damage",
+  "damage": {
+    "type": "uniform",
+    "min": 0.1,
+    "max": 0.2
+  },
+  "add": false
+}

--- a/adventquest_item_modifier/data/att2/item_modifier/durability/remove_1.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/durability/remove_1.json
@@ -1,0 +1,5 @@
+{
+  "function": "set_damage",
+  "damage": -0.1000,
+  "add": true
+}

--- a/adventquest_item_modifier/data/att2/item_modifier/durability/remove_2.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/durability/remove_2.json
@@ -1,0 +1,5 @@
+{
+  "function": "set_damage",
+  "damage": -1,
+  "add": true
+}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/chest.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/chest.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0089,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/feet.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/feet.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.011,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/head.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/head.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.013,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/legs.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/legs.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0095,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.035,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03125,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0275,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/mainhand_unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0325,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/offhand.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending/offhand.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.003,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/chest.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/chest.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0107,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/feet.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/feet.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0131,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/head.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/head.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0155,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/legs.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/legs.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0114,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.042,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0375,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.033,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.036,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/mainhand_unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.039,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/offhand.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_1/offhand.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0036,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/chest.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/chest.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0125,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/feet.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/feet.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0153,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/head.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/head.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0181,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/legs.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/legs.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0133,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.049,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.04375,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0385,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.042,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/mainhand_unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0455,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/offhand.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_2/offhand.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0042,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/chest.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/chest.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0142,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/feet.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/feet.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0175,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/head.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/head.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0207,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/legs.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/legs.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0152,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.056,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.044,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.048,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/mainhand_unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.052,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/offhand.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_3/offhand.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0048,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/chest.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/chest.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0160,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/feet.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/feet.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0197,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/head.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/head.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0233,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/legs.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/legs.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0171,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.063,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05625,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0495,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.054,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/mainhand_unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0585,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/offhand.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_4/offhand.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0054,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/chest.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/chest.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0178,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/feet.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/feet.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0219,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/head.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/head.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0259,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/legs.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/legs.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0190,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.07,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.0625,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.055,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/mainhand_unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.065,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/offhand.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/eternan_automending_lvl_5/offhand.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.006,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.28,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.32,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.44,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.34,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.22,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.27,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.45,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.38,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.31,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.14,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.19,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.11,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/armor/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.01,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.07,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.005,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.28,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.14,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.04,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.36,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.02,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.075,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.015,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.01,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level0/weapon/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.04,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.07,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.34,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.48,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.38,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.34,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.53,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.41,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.26,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.48,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.32,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.53,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.45,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.37,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.48,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.21,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.23,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.11,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/armor/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.14,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.015,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.005,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.04,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.11,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.34,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.48,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.43,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.14,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.04,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.07,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.02,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.11,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.01,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level1/weapon/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.27,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.45,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.64,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.51,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.42,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.71,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.54,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.35,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.53,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.32,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.64,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.43,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.53,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.71,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.64,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.28,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.22,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.53,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.27,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/armor/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.19,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.02,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.01,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.27,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.32,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.14,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.45,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.64,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.22,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.27,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.32,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.07,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.53,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.53,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.58,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.19,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.32,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.16,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.04,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.16,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.14,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.02,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.32,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level2/weapon/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.11,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.16,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.56,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.64,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.52,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.89,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.68,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.43,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.67,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.53,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.67,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.89,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.76,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.62,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.35,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.28,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.67,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.38,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.22,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/armor/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.23,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.02,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.57,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.28,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.67,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.67,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.72,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.23,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.11,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.04,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level3/weapon/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.67,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.95,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.77,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.62,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.82,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.52,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.48,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.95,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.64,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.90,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.75,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.95,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.36,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.42,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.45,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.22,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.26,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/armor/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.28,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.16,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.02,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.07,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.48,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.21,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.68,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.95,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.36,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.40,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.48,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.36,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.85,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.28,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.48,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.14,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.18,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.05,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.21,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.48,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level4/weapon/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.10,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.19,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.38,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.23,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.24,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.84,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.95,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.78,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.65,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.75,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.80,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.45,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.75,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.53,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.41,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.56,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/ult/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.28,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.33,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.75,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/armor/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.35,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.04,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.20,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.03,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/com/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.26,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.85,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.23,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.41,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.45,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.15,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.50,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.13,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/epi_esc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.25,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.75,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.45,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.35,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/leg/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.09,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.38,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.38,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.08,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.75,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/rar/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.17,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.9,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.75,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.75,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 1.00,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/ult/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.90,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.23,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/delightful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/delightful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.06,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/eternan.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/eternan.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.30,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/graceful.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/graceful.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.26,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/harmonious.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/harmonious.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.04,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/teran.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/teran.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.60,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/traditional.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/mending/level5/weapon/unc/traditional.json
@@ -1,5 +1,0 @@
-{
-  "function": "set_damage",
-  "damage": 0.12,
-  "add": true
-}

--- a/adventquest_item_modifier/data/att2/item_modifier/qucik_pick_up.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/qucik_pick_up.json
@@ -1,0 +1,30 @@
+[
+  {
+    "function": "fill_player_head",
+    "entity": "this"
+  },
+  {
+    "function": "minecraft:set_components",
+    "components": {
+      "minecraft:custom_name": {
+        "translate": "att2.quick_pick_up.name"
+      },
+      "minecraft:lore": [
+        {
+          "translate": "att2.quick_pick_up.lore.1"
+        },
+        {
+          "translate": "att2.quick_pick_up.lore.2"
+        },
+        {
+          "translate": "att2.quick_pick_up.lore.3"
+        }
+      ],
+      "minecraft:custom_data": {
+        "EquipmentType": "misc",
+        "Rarity": "misc",
+        "limit":true
+      }
+    }
+  }
+]

--- a/adventquest_item_modifier/data/att2/item_modifier/set_player_head.json
+++ b/adventquest_item_modifier/data/att2/item_modifier/set_player_head.json
@@ -1,0 +1,4 @@
+{
+  "function": "fill_player_head",
+  "entity": "this"
+}

--- a/adventquest_loot_table/data/att2/loot_table/item_data/quest/all_chest.json
+++ b/adventquest_loot_table/data/att2/loot_table/item_data/quest/all_chest.json
@@ -438,7 +438,7 @@
                         }
                     ],
                     "type": "minecraft:loot_table",
-                    "value": "att2:item_data/quest/keys/score_key"
+                    "value": "att2:item_data/quest/keys/storage_key"
                 },
                 {
                     "conditions": [


### PR DESCRIPTION
- Modify the boss's title display so that it triggers every time the player enters the boss door, rather than only triggering once at a specific phase.
-  Convert all boss bar texts into translation keys.
- Fixed a bug: when players were fighting a boss inside the boss room and died, if they re-entered the boss room within 0.5 seconds of their death, the boss would be directly marked as dead. The main reason is the previously mentioned issue—after an entity dies, there is a 0.5-second death animation. During this period, an entity with the same UUID cannot be spawned, causing the boss to be incorrectly determined as already dead.So now, whether the player fails or wins in a boss fight, the boss room will enter a 2-second cooldown, during which the related boss logic will not run, preventing any judgment errors.